### PR TITLE
fix naming to avoid error

### DIFF
--- a/romtools/trial_space_utils/svd_method_of_snapshots.py
+++ b/romtools/trial_space_utils/svd_method_of_snapshots.py
@@ -7,6 +7,68 @@ except ModuleNotFoundError:
   mpi_rank = 0
   num_processes = 1
 
+## Helper functions will be moved to python mpi library at some point
+
+def A_transpose_dot_bImpl(A,b,comm):
+  """
+  @private
+  Compute A^T A when A's columns are distributed
+  """
+  mpi_rank = comm.Get_rank()
+  num_processes = comm.Get_size()
+
+  if (num_processes == 1):
+    return np.dot(A.transpose(),b)
+  else:
+    tmp = np.dot(A.transpose(),b)
+
+    data = comm.gather(tmp.flatten(),root = 0)
+
+    ATb_glob = np.zeros(np.size(tmp))
+    if (mpi_rank == 0):
+      for j in range(0,num_processes):
+        ATb_glob[:] += data[j]
+      for j in range(1,num_processes):
+        comm.Send(ATb_glob, dest=j)
+
+    else:
+        comm.Recv(ATb_glob, source=0)
+    return np.reshape( ATb_glob , np.shape(tmp) )
+
+def svdMethodOfSnapshotsImpl(snapshots,comm):
+  """@private"""
+  #
+  # outputs:
+  # modes, Phi: numpy array where each column is a POD mode
+  # energy, sigma: energy associated with each mode (singular values)
+  
+  STS = A_transpose_dot_bImpl(snapshots,snapshots,comm)
+  Lam,E = np.linalg.eig(STS)
+  sigma = np.sqrt(Lam) 
+  U = np.zeros(np.shape(snapshots) )
+  U[:] = np.dot(snapshots, np.dot(E , np.diag(1./sigma)))
+  ## sort by singular values
+  ordering = np.argsort(sigma)[::-1]
+  return U[:,ordering],sigma[ordering]
+
+def globalAbsSumImpl(r):
+  """@private"""
+  if (num_processes == 1):
+    return np.sum(r)
+  else:
+    data = comm.gather(np.sum(np.abs(r)),root = 0)
+    rn_glob = np.zeros(1)
+    if (mpi_rank == 0):
+      for j in range(0,num_processes):
+        rn_glob[:] += data[j]
+      for j in range(1,num_processes):
+        comm.Send(rn_glob, dest=j)
+    else:
+      comm.Recv(rn_glob,source=0)
+    return rn_glob[0]
+
+
+
 class svdMethodOfSnapshots:
   '''
   #Parallel implementation of the method of snapshots to mimic the SVD for basis construction
@@ -46,63 +108,4 @@ class svdMethodOfSnapshotsForQr:
     U,s = svdMethodOfSnapshotsImpl(snapshots,self._comm)
     return U,'not_computed_in_method_of_snapshots'
 
-
-def __svdMethodOfSnapshotsImpl(snapshots,comm):
-  #
-  # outputs:
-  # modes, Phi: numpy array where each column is a POD mode
-  # energy, sigma: energy associated with each mode (singular values)
-  
-  STS = __A_transpose_dot_b(snapshots,snapshots,comm)
-  Lam,E = np.linalg.eig(STS)
-  sigma = np.sqrt(Lam) 
-  U = np.zeros(np.shape(snapshots) )
-  U[:] = np.dot(snapshots, np.dot(E , np.diag(1./sigma)))
-  ## sort by singular values
-  ordering = np.argsort(sigma)[::-1]
-  return U[:,ordering],sigma[ordering]
-
-
-
-def __globalAbsSum(r):
-  if (num_processes == 1):
-    return np.sum(r)
-  else:
-    data = comm.gather(np.sum(np.abs(r)),root = 0)
-    rn_glob = np.zeros(1)
-    if (mpi_rank == 0):
-      for j in range(0,num_processes):
-        rn_glob[:] += data[j]
-      for j in range(1,num_processes):
-        comm.Send(rn_glob, dest=j)
-    else:
-      comm.Recv(rn_glob,source=0)
-    return rn_glob[0]
-
-## Helper functions will be moved to python mpi library at some point
-
-def __A_transpose_dot_b(A,b,comm):
-  '''
-  Compute A^T A when A's columns are distributed
-  '''
-  mpi_rank = comm.Get_rank()
-  num_processes = comm.Get_size()
-
-  if (num_processes == 1):
-    return np.dot(A.transpose(),b)
-  else:
-    tmp = np.dot(A.transpose(),b)
-
-    data = comm.gather(tmp.flatten(),root = 0)
-
-    ATb_glob = np.zeros(np.size(tmp))
-    if (mpi_rank == 0):
-      for j in range(0,num_processes):
-        ATb_glob[:] += data[j]
-      for j in range(1,num_processes):
-        comm.Send(ATb_glob, dest=j)
-
-    else:
-        comm.Recv(ATb_glob, source=0)
-    return np.reshape( ATb_glob , np.shape(tmp) )
 


### PR DESCRIPTION
this PR does two things:
- reorder things inside svd_kernel_trick so that impl functions are the top 
- remove underscores from the names (this was causing a failure for me)