### PR TITLE
make `truncater` more expressive

### DIFF
--- a/romtools/vector_space/__init__.py
+++ b/romtools/vector_space/__init__.py
@@ -89,7 +89,7 @@ which derive from the abstract class `VectorSpace`.
 import abc
 from typing import Callable
 import numpy as np
-from romtools.vector_space.utils.truncater import Truncater, NoOpTruncater
+from romtools.vector_space.utils.truncater import SVDBasisTruncater, NoOpTruncater
 from romtools.vector_space.utils.shifter import _Shifter, create_noop_shifter
 from romtools.vector_space.utils.scaler import Scaler, NoOpScaler
 from romtools.vector_space.utils.splitter import Splitter, NoOpSplitter
@@ -217,7 +217,7 @@ class VectorSpaceFromPOD(VectorSpace):
 
     def __init__(self,
                  snapshots,
-                 truncater:      Truncater      = NoOpTruncater(),
+                 truncater:      SVDBasisTruncater      = NoOpTruncater(),
                  shifter:        _Shifter       = None,
                  splitter:       Splitter       = NoOpSplitter(),
                  orthogonalizer: Orthogonalizer = NoOpOrthogonalizer(),

--- a/romtools/vector_space/__init__.py
+++ b/romtools/vector_space/__init__.py
@@ -89,7 +89,7 @@ which derive from the abstract class `VectorSpace`.
 import abc
 from typing import Callable
 import numpy as np
-from romtools.vector_space.utils.truncater import SVDBasisTruncater, NoOpTruncater
+from romtools.vector_space.utils.truncater import LeftSingularVectorTruncater, NoOpTruncater
 from romtools.vector_space.utils.shifter import _Shifter, create_noop_shifter
 from romtools.vector_space.utils.scaler import Scaler, NoOpScaler
 from romtools.vector_space.utils.splitter import Splitter, NoOpSplitter
@@ -217,7 +217,7 @@ class VectorSpaceFromPOD(VectorSpace):
 
     def __init__(self,
                  snapshots,
-                 truncater:      SVDBasisTruncater      = NoOpTruncater(),
+                 truncater:      LeftSingularVectorTruncater   = NoOpTruncater(),
                  shifter:        _Shifter       = None,
                  splitter:       Splitter       = NoOpSplitter(),
                  orthogonalizer: Orthogonalizer = NoOpOrthogonalizer(),

--- a/romtools/vector_space/utils/truncater.py
+++ b/romtools/vector_space/utils/truncater.py
@@ -59,7 +59,7 @@ import abc
 import numpy as np
 
 
-class Truncater(abc.ABC):
+class SVDBasisTruncater(abc.ABC):
     '''
     Abstract implementation
     '''
@@ -72,7 +72,7 @@ class Truncater(abc.ABC):
         pass
 
 
-class NoOpTruncater(Truncater):
+class NoOpTruncater(SVDBasisTruncater):
     '''
     No op implementation
     '''
@@ -83,7 +83,7 @@ class NoOpTruncater(Truncater):
         return basis
 
 
-class BasisSizeTruncater(Truncater):
+class BasisSizeTruncater(SVDBasisTruncater):
     '''
     Truncates to a specified number of singular vectors, as specified in the constructor
     '''
@@ -110,7 +110,7 @@ class BasisSizeTruncater(Truncater):
         return basis[:, :self.__basis_dimension]
 
 
-class EnergyTruncater(Truncater):
+class EnergyBasedTruncater(SVDBasisTruncater):
     '''
     Truncates based on the decay of singular values, i.e., will define $K$ to
     be the number of singular values such that the cumulative energy retained

--- a/romtools/vector_space/utils/truncater.py
+++ b/romtools/vector_space/utils/truncater.py
@@ -59,7 +59,7 @@ import abc
 import numpy as np
 
 
-class SVDBasisTruncater(abc.ABC):
+class LeftSingularVectorTruncater(abc.ABC):
     '''
     Abstract implementation
     '''
@@ -72,7 +72,7 @@ class SVDBasisTruncater(abc.ABC):
         pass
 
 
-class NoOpTruncater(SVDBasisTruncater):
+class NoOpTruncater(LeftSingularVectorTruncater):
     '''
     No op implementation
     '''
@@ -83,7 +83,7 @@ class NoOpTruncater(SVDBasisTruncater):
         return basis
 
 
-class BasisSizeTruncater(SVDBasisTruncater):
+class BasisSizeTruncater(LeftSingularVectorTruncater):
     '''
     Truncates to a specified number of singular vectors, as specified in the constructor
     '''
@@ -110,7 +110,7 @@ class BasisSizeTruncater(SVDBasisTruncater):
         return basis[:, :self.__basis_dimension]
 
 
-class EnergyBasedTruncater(SVDBasisTruncater):
+class EnergyBasedTruncater(LeftSingularVectorTruncater):
     '''
     Truncates based on the decay of singular values, i.e., will define $K$ to
     be the number of singular values such that the cumulative energy retained

--- a/tests/romtools/test_vector_space_utils/test_truncater.py
+++ b/tests/romtools/test_vector_space_utils/test_truncater.py
@@ -33,7 +33,7 @@ def test_energy_truncater():
     if energy[i] < energy_threshold:
       K += 1
 
-  truncater = EnergyTruncater(energy_threshold)
+  truncater = EnergyBasedTruncater(energy_threshold)
   my_basis = np.random.normal(size=(10,8))
   my_truncated_basis = truncater.truncate(my_basis,singular_values)
   assert(np.allclose(my_truncated_basis,my_basis[:,0:K]))


### PR DESCRIPTION
the truncator is (in its current form) only applicable (and makes sense) to a matrix that is the result of an svd .
IMO the current name was too generic. 
This PR improves the name to make it more explicit what we are doing 
