### PR TITLE
179 residual evaluator

### DIFF
--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -8,14 +8,15 @@ import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
 
-class SteadyResidualEvaluator(Protocol):
+class ResidualEvaluator(Protocol):
     '''
-    Baseline steady residual evaluator protocol
+    Baseline residual evaluator protocol
     '''
 
-    def load_projected_full_solution(self, filename: str) -> np.ndarray:
+    def compute_reduced_state(self, filename: str) -> np.ndarray:
         '''
-        Reads the full-order model solution from the specified filename
+        Reads the full-order model solution from the specified filename 
+        and computes the corresponding reduced state
 
         Args:
             filename (str): filename of the file containing the full-order model solution data
@@ -26,31 +27,10 @@ class SteadyResidualEvaluator(Protocol):
         '''
         pass
 
-    def evaluate_full_residual(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
+    def compute_reduced_states(self, filename: str) -> (np.ndarray,np.ndarray):
         '''
-        Evaluate the full-order model residual corresponding to a full state reconstructed from
-        a reduced state reduced_state
-
-        Args:
-            run_directory (str): Absolute path to directory in which residual is being computed. 
-            full_model_directory (str): Absolute path to directory in which the full model data was computed. 
-            reduced_state (np.ndarray): 1-dimensional reduced state vector. 
-
-        Returns:
-            `np.ndarray`: The full-order residual in tensor form.
-        '''
-        # TODO should this just return a list of directories instead?
-        pass
-
-# TODO populate_run_directory method as well?
-class UnsteadyResidualEvaluator(Protocol):
-    '''
-    Baseline unsteady residual evaluator protocol
-    '''
-
-    def load_projected_full_solutions(self, filename: str) -> (np.ndarray,np.ndarray):
-        '''
-        Reads the full-order model solutions and time steps from the specified filename
+        Reads the full-order model solution and time stamps from the specified filename 
+        and computes the corresponding reduced states
 
         Args:
             filename (str): filename of the file containing the full-order model solution data
@@ -62,7 +42,7 @@ class UnsteadyResidualEvaluator(Protocol):
         '''
         pass
 
-    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> (np.ndarray):
+    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray=None) -> np.ndarray:
         '''
         Evaluate the full-order model residuals corresponding to full states reconstructed from
         an array of reduced states, reduced_states
@@ -71,7 +51,7 @@ class UnsteadyResidualEvaluator(Protocol):
             run_directory (str): Absolute path to directory in which residual is being computed. 
             full_model_directory (str): Absolute path to directory in which the full model data was computed. 
             reduced_state (np.ndarray): 2-dimensional reduced state vector. 
-            times (np.ndarray): 1-dimensional vector of time stamps. 
+            times (np.ndarray, optional): 1-dimensional vector of time stamps. 
 
         Returns:
             `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
@@ -79,9 +59,7 @@ class UnsteadyResidualEvaluator(Protocol):
         # TODO should this just return a list of directories instead?
         pass
 
-# TODO populate_run_directory method as well?
-
-def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidualEvaluator,
+def evaluate_and_load_steady_residual_snapshots(residual_evaluator: ResidualEvaluator,
                                                 full_state_directories: list[str],
                                                 state_filename: str,
                                                 absolute_run_directory: str) -> np.ndarray:
@@ -107,18 +85,16 @@ def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidu
     n_x = -1
     for index,full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshot
-        reduced_state = residual_evaluator.load_projected_full_solution(full_model_dir+'/'+state_filename)
+        reduced_state = residual_evaluator.compute_reduced_state(full_model_dir+'/'+state_filename)
         
         # Set up corresponding directory
         run_directory = f'{run_directory_base}{index}'
         create_empty_dir(run_directory)
         
         # Evaluate residual
-        residual_snapshot = residual_evaluator.evaluate_full_residual(run_directory,full_model_dir,reduced_state)
+        residual_snapshot = residual_evaluator.evaluate_full_residuals(run_directory,full_model_dir,reduced_state)
 
         # check residual snapshot size and shape
-        assert(residual_snapshot.ndim == 2)
-        residual_snapshot = np.expand_dims(residual_snapshot, axis=2)
         if n_vars == -1 and n_x == -1:
             n_vars = residual_snapshot.shape[0]
             n_x = residual_snapshot.shape[1]
@@ -132,7 +108,7 @@ def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidu
     return np.concatenate(all_residual_snapshots,axis=2)
 
 
-def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: UnsteadyResidualEvaluator,
+def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: ResidualEvaluator,
                                                   full_state_directories: list[str],
                                                   state_filename: str,
                                                   absolute_run_directory: str) -> np.ndarray:
@@ -158,7 +134,7 @@ def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: UnsteadyRe
     n_x = -1
     for index,full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
-        reduced_states, times = residual_evaluator.load_projected_full_solutions(full_model_dir+'/'+state_filename)
+        reduced_states, times = residual_evaluator.compute_reduced_states(full_model_dir+'/'+state_filename)
 
         # Set up corresponding directory
         run_directory = f'{run_directory_base}{index}'

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -3,7 +3,7 @@ Protocol for interfacing with external application to compute residual snapshots
 corresponding to existing state snapshots.
 """
 
-from typing import Protocol, Iterable
+from typing import Protocol, Iterable, Tuple
 import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
@@ -28,7 +28,7 @@ class ResidualEvaluator(Protocol):
         """
         pass
 
-    def compute_reduced_states(self, filename: str) -> tuple[np.ndarray, np.ndarray]:
+    def compute_reduced_states(self, filename: str) -> Tuple[np.ndarray, np.ndarray]:
         """
         Reads the full-order model solution and time stamps from the specified filename
         and computes the corresponding reduced states

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -3,7 +3,7 @@ Protocol for interfacing with external application to compute residual snapshots
 corresponding to existing state snapshots.
 """
 
-from typing import Protocol, Iterable
+from typing import Protocol
 import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
@@ -63,7 +63,6 @@ class ResidualEvaluator(Protocol):
         Returns:
             `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
         """
-        # TODO should this just return a list of directories instead?
         pass
 
 
@@ -151,9 +150,6 @@ def evaluate_and_load_unsteady_residual_snapshots(
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
         reduced_states, times = residual_evaluator.compute_reduced_states(
-            full_model_dir + "/" + state_filename
-        )
-        reduced_states, times = residual_evaluator.load_projected_full_solutions(
             full_model_dir + "/" + state_filename
         )
 

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -3,7 +3,7 @@ Protocol for interfacing with external application to compute residual snapshots
 corresponding to existing state snapshots.
 """
 
-from typing import Protocol
+from typing import Protocol, Iterable
 import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
@@ -86,7 +86,7 @@ class UnsteadyResidualEvaluator(Protocol):
 
 
 def evaluate_and_load_steady_residual_snapshots(
-    residual_evaluator: SteadyResidualEvaluator, full_state_directories: list[str], state_filename: str, absolute_run_directory: str
+    residual_evaluator: SteadyResidualEvaluator, full_state_directories: Iterable[str], state_filename: str, absolute_run_directory: str
 ) -> np.ndarray:
     """
     Core algorithm that takes a residual_evaluator, a list of steady full-order model
@@ -136,7 +136,7 @@ def evaluate_and_load_steady_residual_snapshots(
 
 
 def evaluate_and_load_unsteady_residual_snapshots(
-    residual_evaluator: UnsteadyResidualEvaluator, full_state_directories: list[str], state_filename: str, absolute_run_directory: str
+    residual_evaluator: UnsteadyResidualEvaluator, full_state_directories: Iterable[str], state_filename: str, absolute_run_directory: str
 ) -> np.ndarray:
     """
     Core algorithm that takes a residual_evaluator, a list of unsteady full-order model

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -1,0 +1,194 @@
+'''
+Protocol for interfacing with external application to compute residual snapshots 
+corresponding to existing state snapshots. 
+'''
+
+from typing import Protocol
+import numpy as np
+
+from romtools.workflows.workflow_utils import create_empty_dir
+
+class SteadyResidualEvaluator(Protocol):
+    '''
+    Baseline steady residual evaluator protocol
+    '''
+
+    def load_projected_full_solution(self, filename: str) -> np.ndarray:
+        '''
+        Reads the full-order model solution from the specified filename
+
+        Args:
+            filename (str): filename of the file containing the full-order model solution data
+
+        Returns:
+            `np.ndarray`: The projected full-order solution in a 1-dimensional array
+
+        '''
+        pass
+
+    def evaluate_full_residual(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
+        '''
+        Evaluate the full-order model residual corresponding to a full state reconstructed from
+        a reduced state reduced_state
+
+        Args:
+            run_directory (str): Absolute path to directory in which residual is being computed. 
+            full_model_directory (str): Absolute path to directory in which the full model data was computed. 
+            reduced_state (np.ndarray): 1-dimensional reduced state vector. 
+
+        Returns:
+            `np.ndarray`: The full-order residual in tensor form.
+        '''
+        pass
+
+class UnsteadyResidualEvaluator(Protocol):
+    '''
+    Baseline unsteady residual evaluator protocol
+    '''
+
+    def load_projected_full_solutions(self, filename: str) -> (np.ndarray,np.ndarray):
+        '''
+        Reads the full-order model solutions and time steps from the specified filename
+
+        Args:
+            filename (str): filename of the file containing the full-order model solution data
+
+        Returns:
+            `np.ndarray`: The projected full-order solution in a 2-dimensional array
+            `np.ndarray`: The corresponding solution time stamps in a 1-dimensional array
+
+        '''
+        pass
+
+    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> (np.ndarray):
+        '''
+        Evaluate the full-order model residuals corresponding to full states reconstructed from
+        an array of reduced states, reduced_states
+
+        Args:
+            run_directory (str): Absolute path to directory in which residual is being computed. 
+            full_model_directory (str): Absolute path to directory in which the full model data was computed. 
+            reduced_state (np.ndarray): 2-dimensional reduced state vector. 
+            times (np.ndarray): 1-dimensional vector of time stamps. 
+
+        Returns:
+            `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
+        '''
+        pass
+
+# TODO populate_run_directory method as well?
+
+# how to handle additional meta info needed to read FOM solution snapshot?
+
+
+def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidualEvaluator,
+                                                full_state_directories: list[str],
+                                                state_filename: str,
+                                                absolute_run_directory: str) -> np.ndarray:
+    '''
+    Core algorithm that takes a residual_evaluator, a list of steady full-order model
+    snapshot directories, and a snapshot_filename, and computes the corresponding
+    residual snapshots. 
+
+    Args:
+        residual_evaluator (UnsteadyResidualEvaluator): steady residual evaluator we wish to use
+        full_state_directories (list[str]): list of directories containing full state data
+        state_filename (str): filename or base filename of file containing state data
+        absolute_run_directory (str): absolute path to base directory in which residuals are evaluated
+
+    Returns:
+        `np.ndarray`: The full-order residual snapshots in tensor form.
+    '''
+
+    run_directory_base = f'{absolute_run_directory}/res_'
+
+    all_residual_snapshots = []
+    n_vars = -1
+    n_x = -1
+    for index,full_model_dir in enumerate(full_state_directories):
+        # Read and project FOM snapshot
+        reduced_state = residual_evaluator.load_projected_full_solution(full_model_dir+'/'+state_filename)
+        
+        # Set up corresponding directory
+        run_directory = f'{run_directory_base}{index}'
+        create_empty_dir(run_directory)
+        
+        # Evaluate residual
+        residual_snapshot = residual_evaluator.evaluate_full_residual(run_directory,full_model_dir,reduced_state)
+
+        # check residual snapshot size and shape
+        assert(residual_snapshot.ndim == 2)
+        residual_snapshot = np.expand_dims(residual_snapshot, axis=2)
+        if n_vars == -1 and n_x == -1:
+            n_vars = residual_snapshot.shape[0]
+            n_x = residual_snapshot.shape[1]
+        assert(residual_snapshot.shape[0]==n_vars)
+        assert(residual_snapshot.shape[1]==n_x)
+
+        all_residual_snapshots.append(residual_snapshot)
+
+    # convert list to array
+    # does it kill memory usage to do this?
+    return np.concatenate(all_residual_snapshots,axis=2)
+
+
+def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: UnsteadyResidualEvaluator,
+                                                  full_state_directories: list[str],
+                                                  state_filename: str,
+                                                  absolute_run_directory: str) -> np.ndarray:
+    '''
+    Core algorithm that takes a residual_evaluator, a list of unsteady full-order model
+    snapshot directories, and a snapshot_filename, and computes the corresponding
+    residual snapshots. 
+
+    Args:
+        residual_evaluator (UnsteadyResidualEvaluator): steady residual evaluator we wish to use
+        full_state_directories (list[str]): list of directories containing full state data
+        state_filename (str): filename or base filename of file containing state data
+        absolute_run_directory (str): absolute path to base directory in which residuals are evaluated
+
+    Returns:
+        `np.ndarray`: The full-order residual snapshots in tensor form.
+    '''
+
+    run_directory_base = f'{absolute_run_directory}/res_'
+
+    all_residual_snapshots = []
+    n_vars = -1
+    n_x = -1
+    for index,full_model_dir in enumerate(full_state_directories):
+        # Read and project FOM snapshots
+        reduced_states, times = residual_evaluator.load_projected_full_solutions(full_model_dir+'/'+state_filename)
+
+        # Set up corresponding directory
+        run_directory = f'{run_directory_base}{index}'
+        create_empty_dir(run_directory)
+        
+        # Evaluate residuals
+        residual_snapshots = residual_evaluator.evaluate_full_residuals(run_directory,full_model_dir,reduced_states,times)
+
+        # check residual snapshot size and shape
+        assert(residual_snapshots.ndim == 3)
+        if n_vars == -1 and n_x == -1:
+            n_vars = residual_snapshots.shape[0]
+            n_x = residual_snapshots.shape[1]
+        assert(residual_snapshots.shape[0]==n_vars)
+        assert(residual_snapshots.shape[1]==n_x)
+
+        all_residual_snapshots.append(residual_snapshots)
+
+    # convert list to array
+    # does it kill memory usage to do this?
+    return np.concatenate(all_residual_snapshots,axis=2)
+    
+
+
+    
+
+
+
+
+
+
+    
+    

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -8,14 +8,15 @@ import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
 
+
 class ResidualEvaluator(Protocol):
-    '''
+    """
     Baseline residual evaluator protocol
-    '''
+    """
 
     def compute_reduced_state(self, filename: str) -> np.ndarray:
         """
-        Reads the full-order model solution from the specified filename 
+        Reads the full-order model solution from the specified filename
         and computes the corresponding reduced state
 
         Args:
@@ -27,9 +28,9 @@ class ResidualEvaluator(Protocol):
         """
         pass
 
-    def compute_reduced_states(self, filename: str) -> (np.ndarray,np.ndarray):
+    def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
         """
-        Reads the full-order model solution and time stamps from the specified filename 
+        Reads the full-order model solution and time stamps from the specified filename
         and computes the corresponding reduced states
 
         Args:
@@ -42,16 +43,22 @@ class ResidualEvaluator(Protocol):
         """
         pass
 
-    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray=None) -> np.ndarray:
+    def evaluate_full_residuals(
+        self,
+        run_directory: str,
+        full_model_directory: str,
+        reduced_states: np.ndarray,
+        times: np.ndarray = None,
+    ) -> np.ndarray:
         """
         Evaluate the full-order model residuals corresponding to full states reconstructed from
         an array of reduced states, reduced_states
 
         Args:
-            run_directory (str): Absolute path to directory in which residual is being computed. 
-            full_model_directory (str): Absolute path to directory in which the full model data was computed. 
-            reduced_state (np.ndarray): 2-dimensional reduced state vector. 
-            times (np.ndarray, optional): 1-dimensional vector of time stamps. 
+            run_directory (str): Absolute path to directory in which residual is being computed.
+            full_model_directory (str): Absolute path to directory in which the full model data was computed.
+            reduced_state (np.ndarray): 2-dimensional reduced state vector.
+            times (np.ndarray, optional): 1-dimensional vector of time stamps.
 
         Returns:
             `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
@@ -59,8 +66,13 @@ class ResidualEvaluator(Protocol):
         # TODO should this just return a list of directories instead?
         pass
 
+
 def evaluate_and_load_steady_residual_snapshots(
-    residual_evaluator: ResidualEvaluator, full_state_directories: list[str], state_filename: str, absolute_run_directory: str) -> np.ndarray:
+    residual_evaluator: ResidualEvaluator,
+    full_state_directories: list[str],
+    state_filename: str,
+    absolute_run_directory: str,
+) -> np.ndarray:
     """
     Core algorithm that takes a residual_evaluator, a list of steady full-order model
     snapshot directories, and a snapshot_filename, and computes the corresponding
@@ -83,14 +95,18 @@ def evaluate_and_load_steady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshot
-        reduced_state = residual_evaluator.compute_reduced_state(full_model_dir+'/'+state_filename)
-        
+        reduced_state = residual_evaluator.compute_reduced_state(
+            full_model_dir + "/" + state_filename
+        )
+
         # Set up corresponding directory
         run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
 
         # Evaluate residual
-        residual_snapshot = residual_evaluator.evaluate_full_residuals(run_directory,full_model_dir,reduced_state)
+        residual_snapshot = residual_evaluator.evaluate_full_residuals(
+            run_directory, full_model_dir, reduced_state
+        )
 
         # check residual snapshot size and shape
         if n_vars == -1 and n_x == -1:
@@ -107,7 +123,11 @@ def evaluate_and_load_steady_residual_snapshots(
 
 
 def evaluate_and_load_unsteady_residual_snapshots(
-    residual_evaluator: ResidualEvaluator, full_state_directories: list[str], state_filename: str, absolute_run_directory: str) -> np.ndarray:
+    residual_evaluator: ResidualEvaluator,
+    full_state_directories: list[str],
+    state_filename: str,
+    absolute_run_directory: str,
+) -> np.ndarray:
     """
     Core algorithm that takes a residual_evaluator, a list of unsteady full-order model
     snapshot directories, and a snapshot_filename, and computes the corresponding
@@ -130,15 +150,21 @@ def evaluate_and_load_unsteady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
-        reduced_states, times = residual_evaluator.compute_reduced_states(full_model_dir+'/'+state_filename)
-        reduced_states, times = residual_evaluator.load_projected_full_solutions(full_model_dir + "/" + state_filename)
+        reduced_states, times = residual_evaluator.compute_reduced_states(
+            full_model_dir + "/" + state_filename
+        )
+        reduced_states, times = residual_evaluator.load_projected_full_solutions(
+            full_model_dir + "/" + state_filename
+        )
 
         # Set up corresponding directory
         run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
 
         # Evaluate residuals
-        residual_snapshots = residual_evaluator.evaluate_full_residuals(run_directory, full_model_dir, reduced_states, times)
+        residual_snapshots = residual_evaluator.evaluate_full_residuals(
+            run_directory, full_model_dir, reduced_states, times
+        )
 
         # check residual snapshot size and shape
         assert residual_snapshots.ndim == 3

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -52,7 +52,7 @@ class ResidualEvaluator(Protocol):
     ) -> np.ndarray:
         """
         Evaluate the full-order model residuals corresponding to full states reconstructed from
-        an array of reduced states, reduced_states
+        an array of reduced states
 
         Args:
             run_directory (str): Absolute path to directory in which residual is being computed.

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -37,8 +37,14 @@ class ResidualEvaluator(Protocol):
             filename (str): filename of the file containing the full-order model solution data
 
         Returns:
-            `np.ndarray`: The projected full-order solution in a 2-dimensional array
-            `np.ndarray`: The corresponding solution time stamps in a 1-dimensional array
+            `np.ndarray`: The projected full-order solution in a 2- or 3-dimensional array. 1st
+            dimension: reduced state, 2nd dimension: time, 3rd dimension: other states in time
+            stencil. If the array is 2-dimensional, it is assumed that the states are sequential
+            in time.
+            `np.ndarray`: The corresponding solution time stamps in a 1- or 2-dimensional array.
+            The optional 2nd dimension is only needed if the reduced projected full-order solution
+            array is 3-dimensional; the 2nd dimension contains the time stamps of the other states
+            in the time-stencil for a given time stamp.
 
         """
         pass
@@ -48,6 +54,7 @@ class ResidualEvaluator(Protocol):
         run_directory: str,
         full_model_directory: str,
         reduced_states: np.ndarray,
+        parameter_sample: dict,
         times: np.ndarray = None,
     ) -> np.ndarray:
         """
@@ -57,8 +64,13 @@ class ResidualEvaluator(Protocol):
         Args:
             run_directory (str): Absolute path to directory in which residual is being computed.
             full_model_directory (str): Absolute path to directory in which the full model data was computed.
-            reduced_state (np.ndarray): 2-dimensional reduced state vector.
-            times (np.ndarray, optional): 1-dimensional vector of time stamps.
+            reduced_state (np.ndarray): 2- or 3-dimensional reduced state vector. 1st dimension: reduced state,
+            2nd dimension: time, 3rd dimension: other states in time stencil. If the array is 2-dimensional, it
+            is assumed that the states are sequential in time.
+            parameter_sample: Dictionary contatining parameter names and sample values
+            times (np.ndarray, optional): 1-dimensional or 2-dimesional vector of time stamps. The optional
+            2nd dimension is only needed if the reduced state array is 3-dimensional; the 2nd dimension
+            contains the time stamps of the other states in the time-stencil for a given time stamp.
 
         Returns:
             `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
@@ -94,14 +106,18 @@ def evaluate_and_load_steady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshot
-        reduced_state = residual_evaluator.compute_reduced_state(full_model_dir + "/" + state_filename)
+        reduced_state = residual_evaluator.compute_reduced_state(
+            full_model_dir + "/" + state_filename
+        )
 
         # Set up corresponding directory
         run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
 
         # Evaluate residual
-        residual_snapshot = residual_evaluator.evaluate_full_residuals(run_directory, full_model_dir, reduced_state)
+        residual_snapshot = residual_evaluator.evaluate_full_residuals(
+            run_directory, full_model_dir, reduced_state, None
+        )
 
         # check residual snapshot size and shape
         if n_vars == -1 and n_x == -1:
@@ -145,14 +161,18 @@ def evaluate_and_load_unsteady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
-        reduced_states, times = residual_evaluator.compute_reduced_states(full_model_dir + "/" + state_filename)
+        reduced_states, times = residual_evaluator.compute_reduced_states(
+            full_model_dir + "/" + state_filename
+        )
 
         # Set up corresponding directory
         run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
 
         # Evaluate residuals
-        residual_snapshots = residual_evaluator.evaluate_full_residuals(run_directory, full_model_dir, reduced_states, times)
+        residual_snapshots = residual_evaluator.evaluate_full_residuals(
+            run_directory, full_model_dir, reduced_states, None, times
+        )
 
         # check residual snapshot size and shape
         assert residual_snapshots.ndim == 3

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -3,7 +3,7 @@ Protocol for interfacing with external application to compute residual snapshots
 corresponding to existing state snapshots.
 """
 
-from typing import Protocol
+from typing import Protocol, Iterable
 import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
@@ -28,7 +28,7 @@ class ResidualEvaluator(Protocol):
         """
         pass
 
-    def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
+    def compute_reduced_states(self, filename: str) -> tuple[np.ndarray, np.ndarray]:
         """
         Reads the full-order model solution and time stamps from the specified filename
         and computes the corresponding reduced states
@@ -68,7 +68,7 @@ class ResidualEvaluator(Protocol):
 
 def evaluate_and_load_steady_residual_snapshots(
     residual_evaluator: ResidualEvaluator,
-    full_state_directories: list[str],
+    full_state_directories: Iterable[str],
     state_filename: str,
     absolute_run_directory: str,
 ) -> np.ndarray:
@@ -94,18 +94,14 @@ def evaluate_and_load_steady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshot
-        reduced_state = residual_evaluator.compute_reduced_state(
-            full_model_dir + "/" + state_filename
-        )
+        reduced_state = residual_evaluator.compute_reduced_state(full_model_dir + "/" + state_filename)
 
         # Set up corresponding directory
         run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
 
         # Evaluate residual
-        residual_snapshot = residual_evaluator.evaluate_full_residuals(
-            run_directory, full_model_dir, reduced_state
-        )
+        residual_snapshot = residual_evaluator.evaluate_full_residuals(run_directory, full_model_dir, reduced_state)
 
         # check residual snapshot size and shape
         if n_vars == -1 and n_x == -1:
@@ -123,7 +119,7 @@ def evaluate_and_load_steady_residual_snapshots(
 
 def evaluate_and_load_unsteady_residual_snapshots(
     residual_evaluator: ResidualEvaluator,
-    full_state_directories: list[str],
+    full_state_directories: Iterable[str],
     state_filename: str,
     absolute_run_directory: str,
 ) -> np.ndarray:
@@ -149,18 +145,14 @@ def evaluate_and_load_unsteady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
-        reduced_states, times = residual_evaluator.compute_reduced_states(
-            full_model_dir + "/" + state_filename
-        )
+        reduced_states, times = residual_evaluator.compute_reduced_states(full_model_dir + "/" + state_filename)
 
         # Set up corresponding directory
         run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
 
         # Evaluate residuals
-        residual_snapshots = residual_evaluator.evaluate_full_residuals(
-            run_directory, full_model_dir, reduced_states, times
-        )
+        residual_snapshots = residual_evaluator.evaluate_full_residuals(run_directory, full_model_dir, reduced_states, times)
 
         # check residual snapshot size and shape
         assert residual_snapshots.ndim == 3

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -14,21 +14,52 @@ class ResidualEvaluator(Protocol):
     Baseline residual evaluator protocol
     """
 
-    def compute_reduced_state(self, filename: str) -> np.ndarray:
+    def compute_reduced_states(self, filename: str) -> np.ndarray:
         """
-        Reads the full-order model solution from the specified filename
-        and computes the corresponding reduced state
+        Reads the full-order model solution(s) from the specified filename
+        and computes the corresponding reduced state(s)
 
         Args:
             filename (str): filename of the file containing the full-order model solution data
 
         Returns:
-            `np.ndarray`: The projected full-order solution in a 1-dimensional array
+            `np.ndarray`: The projected full-order solution in a 1- or 2-dimensional array.
+            1st dimension: reduced state, 2nd dimension: sample index corresponding full-model
+            solution data file.
 
         """
         pass
 
-    def compute_reduced_states(self, filename: str) -> Tuple[np.ndarray, np.ndarray]:
+    def evaluate_full_residuals(
+        self,
+        run_directory: str,
+        full_model_directory: str,
+        reduced_states: np.ndarray,
+        parameter_sample: dict,
+    ) -> np.ndarray:
+        """
+        Evaluate the full-order model residuals corresponding to full states reconstructed from
+        an array of reduced states
+
+        Args:
+            run_directory (str): Absolute path to directory in which residual is being computed.
+            full_model_directory (str): Absolute path to directory in which the full model data was computed.
+            reduced_state (np.ndarray): 2-dimensional reduced state vector. 1st dimension: reduced state,
+            2nd dimension: sample index
+            parameter_sample: Dictionary contatining parameter names and sample values
+
+        Returns:
+            `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single sample
+        """
+        pass
+
+
+class TransientResidualEvaluator(Protocol):
+    """
+    Baseline residual evaluator protocol
+    """
+
+    def compute_reduced_states(self, filename: str) -> np.ndarray:
         """
         Reads the full-order model solution and time stamps from the specified filename
         and computes the corresponding reduced states
@@ -41,6 +72,18 @@ class ResidualEvaluator(Protocol):
             dimension: reduced state, 2nd dimension: time, 3rd dimension: other states in time
             stencil. If the array is 2-dimensional, it is assumed that the states are sequential
             in time.
+
+        """
+        pass
+
+    def get_times(self, filename: str) -> np.ndarray:
+        """
+        Reads and outputs time stamps from the specified filename
+
+        Args:
+            filename (str): filename of the file containing the full-order model solution data
+
+        Returns:
             `np.ndarray`: The corresponding solution time stamps in a 1- or 2-dimensional array.
             The optional 2nd dimension is only needed if the reduced projected full-order solution
             array is 3-dimensional; the 2nd dimension contains the time stamps of the other states
@@ -55,7 +98,7 @@ class ResidualEvaluator(Protocol):
         full_model_directory: str,
         reduced_states: np.ndarray,
         parameter_sample: dict,
-        times: np.ndarray = None,
+        times: np.ndarray,
     ) -> np.ndarray:
         """
         Evaluate the full-order model residuals corresponding to full states reconstructed from
@@ -68,7 +111,7 @@ class ResidualEvaluator(Protocol):
             2nd dimension: time, 3rd dimension: other states in time stencil. If the array is 2-dimensional, it
             is assumed that the states are sequential in time.
             parameter_sample: Dictionary contatining parameter names and sample values
-            times (np.ndarray, optional): 1-dimensional or 2-dimesional vector of time stamps. The optional
+            times (np.ndarray): 1-dimensional or 2-dimesional vector of time stamps. The optional
             2nd dimension is only needed if the reduced state array is 3-dimensional; the 2nd dimension
             contains the time stamps of the other states in the time-stencil for a given time stamp.
 
@@ -90,7 +133,7 @@ def evaluate_and_load_steady_residual_snapshots(
     residual snapshots.
 
     Args:
-        residual_evaluator (UnsteadyResidualEvaluator): steady residual evaluator we wish to use
+        residual_evaluator (ResidualEvaluator): steady residual evaluator we wish to use
         full_state_directories (list[str]): list of directories containing full state data
         state_filename (str): filename or base filename of file containing state data
         absolute_run_directory (str): absolute path to base directory in which residuals are evaluated
@@ -106,7 +149,7 @@ def evaluate_and_load_steady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshot
-        reduced_state = residual_evaluator.compute_reduced_state(
+        reduced_state = residual_evaluator.compute_reduced_states(
             full_model_dir + "/" + state_filename
         )
 
@@ -134,7 +177,7 @@ def evaluate_and_load_steady_residual_snapshots(
 
 
 def evaluate_and_load_unsteady_residual_snapshots(
-    residual_evaluator: ResidualEvaluator,
+    residual_evaluator: TransientResidualEvaluator,
     full_state_directories: Iterable[str],
     state_filename: str,
     absolute_run_directory: str,
@@ -145,7 +188,7 @@ def evaluate_and_load_unsteady_residual_snapshots(
     residual snapshots.
 
     Args:
-        residual_evaluator (UnsteadyResidualEvaluator): steady residual evaluator we wish to use
+        residual_evaluator (TransientResidualEvaluator): transient residual evaluator we wish to use
         full_state_directories (list[str]): list of directories containing full state data
         state_filename (str): filename or base filename of file containing state data
         absolute_run_directory (str): absolute path to base directory in which residuals are evaluated
@@ -161,7 +204,10 @@ def evaluate_and_load_unsteady_residual_snapshots(
     n_x = -1
     for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
-        reduced_states, times = residual_evaluator.compute_reduced_states(
+        reduced_states = residual_evaluator.compute_reduced_states(
+            full_model_dir + "/" + state_filename
+        )
+        times = residual_evaluator.get_times(
             full_model_dir + "/" + state_filename
         )
 

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -39,8 +39,10 @@ class SteadyResidualEvaluator(Protocol):
         Returns:
             `np.ndarray`: The full-order residual in tensor form.
         '''
+        # TODO should this just return a list of directories instead?
         pass
 
+# TODO populate_run_directory method as well?
 class UnsteadyResidualEvaluator(Protocol):
     '''
     Baseline unsteady residual evaluator protocol
@@ -74,12 +76,10 @@ class UnsteadyResidualEvaluator(Protocol):
         Returns:
             `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
         '''
+        # TODO should this just return a list of directories instead?
         pass
 
 # TODO populate_run_directory method as well?
-
-# how to handle additional meta info needed to read FOM solution snapshot?
-
 
 def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidualEvaluator,
                                                 full_state_directories: list[str],
@@ -180,12 +180,6 @@ def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: UnsteadyRe
     # convert list to array
     # does it kill memory usage to do this?
     return np.concatenate(all_residual_snapshots,axis=2)
-    
-
-
-    
-
-
 
 
 

--- a/romtools/workflows/residual_evaluator.py
+++ b/romtools/workflows/residual_evaluator.py
@@ -1,20 +1,21 @@
-'''
-Protocol for interfacing with external application to compute residual snapshots 
-corresponding to existing state snapshots. 
-'''
+"""
+Protocol for interfacing with external application to compute residual snapshots
+corresponding to existing state snapshots.
+"""
 
 from typing import Protocol
 import numpy as np
 
 from romtools.workflows.workflow_utils import create_empty_dir
 
+
 class SteadyResidualEvaluator(Protocol):
-    '''
+    """
     Baseline steady residual evaluator protocol
-    '''
+    """
 
     def load_projected_full_solution(self, filename: str) -> np.ndarray:
-        '''
+        """
         Reads the full-order model solution from the specified filename
 
         Args:
@@ -23,33 +24,34 @@ class SteadyResidualEvaluator(Protocol):
         Returns:
             `np.ndarray`: The projected full-order solution in a 1-dimensional array
 
-        '''
+        """
         pass
 
     def evaluate_full_residual(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
-        '''
+        """
         Evaluate the full-order model residual corresponding to a full state reconstructed from
         a reduced state reduced_state
 
         Args:
-            run_directory (str): Absolute path to directory in which residual is being computed. 
-            full_model_directory (str): Absolute path to directory in which the full model data was computed. 
-            reduced_state (np.ndarray): 1-dimensional reduced state vector. 
+            run_directory (str): Absolute path to directory in which residual is being computed.
+            full_model_directory (str): Absolute path to directory in which the full model data was computed.
+            reduced_state (np.ndarray): 1-dimensional reduced state vector.
 
         Returns:
             `np.ndarray`: The full-order residual in tensor form.
-        '''
+        """
         # TODO should this just return a list of directories instead?
         pass
 
+
 # TODO populate_run_directory method as well?
 class UnsteadyResidualEvaluator(Protocol):
-    '''
+    """
     Baseline unsteady residual evaluator protocol
-    '''
+    """
 
-    def load_projected_full_solutions(self, filename: str) -> (np.ndarray,np.ndarray):
-        '''
+    def load_projected_full_solutions(self, filename: str) -> (np.ndarray, np.ndarray):
+        """
         Reads the full-order model solutions and time steps from the specified filename
 
         Args:
@@ -59,36 +61,37 @@ class UnsteadyResidualEvaluator(Protocol):
             `np.ndarray`: The projected full-order solution in a 2-dimensional array
             `np.ndarray`: The corresponding solution time stamps in a 1-dimensional array
 
-        '''
+        """
         pass
 
-    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> (np.ndarray):
-        '''
+    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> np.ndarray:
+        """
         Evaluate the full-order model residuals corresponding to full states reconstructed from
         an array of reduced states, reduced_states
 
         Args:
-            run_directory (str): Absolute path to directory in which residual is being computed. 
-            full_model_directory (str): Absolute path to directory in which the full model data was computed. 
-            reduced_state (np.ndarray): 2-dimensional reduced state vector. 
-            times (np.ndarray): 1-dimensional vector of time stamps. 
+            run_directory (str): Absolute path to directory in which residual is being computed.
+            full_model_directory (str): Absolute path to directory in which the full model data was computed.
+            reduced_state (np.ndarray): 2-dimensional reduced state vector.
+            times (np.ndarray): 1-dimensional vector of time stamps.
 
         Returns:
             `np.ndarray`: The full-order residual in tensor form, should be 3-dimensional, even for a single time step
-        '''
+        """
         # TODO should this just return a list of directories instead?
         pass
 
+
 # TODO populate_run_directory method as well?
 
-def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidualEvaluator,
-                                                full_state_directories: list[str],
-                                                state_filename: str,
-                                                absolute_run_directory: str) -> np.ndarray:
-    '''
+
+def evaluate_and_load_steady_residual_snapshots(
+    residual_evaluator: SteadyResidualEvaluator, full_state_directories: list[str], state_filename: str, absolute_run_directory: str
+) -> np.ndarray:
+    """
     Core algorithm that takes a residual_evaluator, a list of steady full-order model
     snapshot directories, and a snapshot_filename, and computes the corresponding
-    residual snapshots. 
+    residual snapshots.
 
     Args:
         residual_evaluator (UnsteadyResidualEvaluator): steady residual evaluator we wish to use
@@ -98,48 +101,47 @@ def evaluate_and_load_steady_residual_snapshots(residual_evaluator: SteadyResidu
 
     Returns:
         `np.ndarray`: The full-order residual snapshots in tensor form.
-    '''
+    """
 
-    run_directory_base = f'{absolute_run_directory}/res_'
+    run_directory_base = f"{absolute_run_directory}/res_"
 
     all_residual_snapshots = []
     n_vars = -1
     n_x = -1
-    for index,full_model_dir in enumerate(full_state_directories):
+    for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshot
-        reduced_state = residual_evaluator.load_projected_full_solution(full_model_dir+'/'+state_filename)
-        
+        reduced_state = residual_evaluator.load_projected_full_solution(full_model_dir + "/" + state_filename)
+
         # Set up corresponding directory
-        run_directory = f'{run_directory_base}{index}'
+        run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
-        
+
         # Evaluate residual
-        residual_snapshot = residual_evaluator.evaluate_full_residual(run_directory,full_model_dir,reduced_state)
+        residual_snapshot = residual_evaluator.evaluate_full_residual(run_directory, full_model_dir, reduced_state)
 
         # check residual snapshot size and shape
-        assert(residual_snapshot.ndim == 2)
+        assert residual_snapshot.ndim == 2
         residual_snapshot = np.expand_dims(residual_snapshot, axis=2)
         if n_vars == -1 and n_x == -1:
             n_vars = residual_snapshot.shape[0]
             n_x = residual_snapshot.shape[1]
-        assert(residual_snapshot.shape[0]==n_vars)
-        assert(residual_snapshot.shape[1]==n_x)
+        assert residual_snapshot.shape[0] == n_vars
+        assert residual_snapshot.shape[1] == n_x
 
         all_residual_snapshots.append(residual_snapshot)
 
     # convert list to array
     # does it kill memory usage to do this?
-    return np.concatenate(all_residual_snapshots,axis=2)
+    return np.concatenate(all_residual_snapshots, axis=2)
 
 
-def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: UnsteadyResidualEvaluator,
-                                                  full_state_directories: list[str],
-                                                  state_filename: str,
-                                                  absolute_run_directory: str) -> np.ndarray:
-    '''
+def evaluate_and_load_unsteady_residual_snapshots(
+    residual_evaluator: UnsteadyResidualEvaluator, full_state_directories: list[str], state_filename: str, absolute_run_directory: str
+) -> np.ndarray:
+    """
     Core algorithm that takes a residual_evaluator, a list of unsteady full-order model
     snapshot directories, and a snapshot_filename, and computes the corresponding
-    residual snapshots. 
+    residual snapshots.
 
     Args:
         residual_evaluator (UnsteadyResidualEvaluator): steady residual evaluator we wish to use
@@ -149,40 +151,34 @@ def evaluate_and_load_unsteady_residual_snapshots(residual_evaluator: UnsteadyRe
 
     Returns:
         `np.ndarray`: The full-order residual snapshots in tensor form.
-    '''
+    """
 
-    run_directory_base = f'{absolute_run_directory}/res_'
+    run_directory_base = f"{absolute_run_directory}/res_"
 
     all_residual_snapshots = []
     n_vars = -1
     n_x = -1
-    for index,full_model_dir in enumerate(full_state_directories):
+    for index, full_model_dir in enumerate(full_state_directories):
         # Read and project FOM snapshots
-        reduced_states, times = residual_evaluator.load_projected_full_solutions(full_model_dir+'/'+state_filename)
+        reduced_states, times = residual_evaluator.load_projected_full_solutions(full_model_dir + "/" + state_filename)
 
         # Set up corresponding directory
-        run_directory = f'{run_directory_base}{index}'
+        run_directory = f"{run_directory_base}{index}"
         create_empty_dir(run_directory)
-        
+
         # Evaluate residuals
-        residual_snapshots = residual_evaluator.evaluate_full_residuals(run_directory,full_model_dir,reduced_states,times)
+        residual_snapshots = residual_evaluator.evaluate_full_residuals(run_directory, full_model_dir, reduced_states, times)
 
         # check residual snapshot size and shape
-        assert(residual_snapshots.ndim == 3)
+        assert residual_snapshots.ndim == 3
         if n_vars == -1 and n_x == -1:
             n_vars = residual_snapshots.shape[0]
             n_x = residual_snapshots.shape[1]
-        assert(residual_snapshots.shape[0]==n_vars)
-        assert(residual_snapshots.shape[1]==n_x)
+        assert residual_snapshots.shape[0] == n_vars
+        assert residual_snapshots.shape[1] == n_x
 
         all_residual_snapshots.append(residual_snapshots)
 
     # convert list to array
     # does it kill memory usage to do this?
-    return np.concatenate(all_residual_snapshots,axis=2)
-
-
-
-
-    
-    
+    return np.concatenate(all_residual_snapshots, axis=2)

--- a/romtools/workflows/sampling/sampling.py
+++ b/romtools/workflows/sampling/sampling.py
@@ -72,6 +72,7 @@ def run_sampling(model: Model,
 
     # Setup model directories
     run_directory_base = f'{absolute_sampling_directory}/run_'
+    run_directories = []
     starting_sample_index = 0
     end_sample_index = starting_sample_index + parameter_samples.shape[0]
     for sample_index in range(starting_sample_index, end_sample_index):
@@ -79,6 +80,7 @@ def run_sampling(model: Model,
         create_empty_dir(run_directory)
         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index - starting_sample_index])
         model.populate_run_directory(run_directory, parameter_dict)
+        run_directories.append(run_directory)
 
     # Run cases
     run_times = np.zeros(number_of_samples)
@@ -92,6 +94,8 @@ def run_sampling(model: Model,
         sample_stats_save_directory = f'{run_directory_base}{sample_index}/../'
         np.savez(f'{sample_stats_save_directory}/sampling_stats',
                  run_times=run_times)
+        
+    return run_directories
 
 
 def run_sample(run_directory: str, model: Model,

--- a/tests/romtools/workflows/sampling/test_sampling.py
+++ b/tests/romtools/workflows/sampling/test_sampling.py
@@ -35,9 +35,10 @@ def test_sampler(tmp_path):
                                                np.array([1, 2, 3]),
                                                sampler=MonteCarloSampler)
     my_model = MockModel()
-    run_sampling(my_model, my_parameter_space,
-                 absolute_sampling_directory=tmp_path,
-                 number_of_samples=10)
+    run_directories = run_sampling(my_model, my_parameter_space,
+                                   absolute_sampling_directory=tmp_path,
+                                   number_of_samples=10)
+    assert(len(run_directories)==10)
 
     for i in range(0, 10):
         assert os.path.isdir(f'{tmp_path}/run_' + str(i))

--- a/tests/romtools/workflows/test_residual_evaluator.py
+++ b/tests/romtools/workflows/test_residual_evaluator.py
@@ -10,54 +10,70 @@ class MockSteadyResidualEvaluator:
         pass
 
     def compute_reduced_state(self, filename: str) -> np.ndarray:
-        return np.zeros((3,4))
+        return np.zeros((3, 4))
 
-    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
-        return np.zeros((3,10,1))
-                      
+    def evaluate_full_residuals(
+        self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray
+    ) -> np.ndarray:
+        return np.zeros((3, 10, 1))
+
+
 class MockUnsteadyResidualEvaluator:
     def __init__(self):
         pass
 
-    def compute_reduced_states(self, filename: str) -> (np.ndarray,np.ndarray):
-        return np.zeros((3,4,5)),np.ones(5)
-    
-    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> (np.ndarray):
-        return np.zeros((3,10,5))
+    def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
+        return np.zeros((3, 4, 5)), np.ones(5)
+
+    def evaluate_full_residuals(
+        self,
+        run_directory: str,
+        full_model_directory: str,
+        reduced_states: np.ndarray,
+        times: np.ndarray,
+    ) -> np.ndarray:
+        return np.zeros((3, 10, 5))
+
 
 @pytest.mark.mpi_skip
 def test_steady_residual_evaluator(tmp_path):
     # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
-    print('\n', tmp_path)
+    print("\n", tmp_path)
 
     residual_evaluator = MockSteadyResidualEvaluator()
     num_dirs = 5
     fom_dirs = ["{tmp_path}/run_{i}" for i in range(num_dirs)]
     fom_filename = "dummy"
 
-    res_snaps = evaluate_and_load_steady_residual_snapshots(residual_evaluator,fom_dirs,fom_filename,tmp_path)
-    
-    assert(res_snaps.shape == (3,10,num_dirs))
+    res_snaps = evaluate_and_load_steady_residual_snapshots(
+        residual_evaluator, fom_dirs, fom_filename, tmp_path
+    )
+
+    assert res_snaps.shape == (3, 10, num_dirs)
 
     for i in range(num_dirs):
-        assert(os.path.isdir(f'{tmp_path}/res_' + str(i)))
+        assert os.path.isdir(f"{tmp_path}/res_" + str(i))
+
 
 @pytest.mark.mpi_skip
 def test_unsteady_residual_evaluator(tmp_path):
     # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
-    print('\n', tmp_path)
+    print("\n", tmp_path)
 
     residual_evaluator = MockUnsteadyResidualEvaluator()
     num_dirs = 3
     fom_dirs = ["{tmp_path}/run_{i}" for i in range(num_dirs)]
     fom_filename = "dummy"
 
-    res_snaps = evaluate_and_load_unsteady_residual_snapshots(residual_evaluator,fom_dirs,fom_filename,tmp_path)
-    
-    assert(res_snaps.shape == (3,10,num_dirs*5))
+    res_snaps = evaluate_and_load_unsteady_residual_snapshots(
+        residual_evaluator, fom_dirs, fom_filename, tmp_path
+    )
+
+    assert res_snaps.shape == (3, 10, num_dirs * 5)
 
     for i in range(num_dirs):
-        assert(os.path.isdir(f'{tmp_path}/res_' + str(i)))
+        assert os.path.isdir(f"{tmp_path}/res_" + str(i))
+
 
 if __name__ == "__main__":
     test_steady_residual_evaluator()

--- a/tests/romtools/workflows/test_residual_evaluator.py
+++ b/tests/romtools/workflows/test_residual_evaluator.py
@@ -1,0 +1,64 @@
+import pytest
+import os
+import numpy as np
+
+from romtools.workflows.residual_evaluator import *
+
+
+class MockSteadyResidualEvaluator:
+    def __init__(self):
+        pass
+
+    def load_projected_full_solution(self, filename: str) -> np.ndarray:
+        return np.zeros((3,4))
+
+    def evaluate_full_residual(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
+        return np.zeros((3,10))
+                      
+class MockUnsteadyResidualEvaluator:
+    def __init__(self):
+        pass
+
+    def load_projected_full_solutions(self, filename: str) -> (np.ndarray,np.ndarray):
+        return np.zeros((3,4,5)),np.ones(5)
+    
+    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> (np.ndarray):
+        return np.zeros((3,10,5))
+
+@pytest.mark.mpi_skip
+def test_steady_residual_evaluator(tmp_path):
+    # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
+    print('\n', tmp_path)
+
+    residual_evaluator = MockSteadyResidualEvaluator()
+    num_dirs = 5
+    fom_dirs = ["{tmp_path}/run_{i}" for i in range(num_dirs)]
+    fom_filename = "dummy"
+
+    res_snaps = evaluate_and_load_steady_residual_snapshots(residual_evaluator,fom_dirs,fom_filename,tmp_path)
+    
+    assert(res_snaps.shape == (3,10,num_dirs))
+
+    for i in range(num_dirs):
+        assert(os.path.isdir(f'{tmp_path}/res_' + str(i)))
+
+@pytest.mark.mpi_skip
+def test_unsteady_residual_evaluator(tmp_path):
+    # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
+    print('\n', tmp_path)
+
+    residual_evaluator = MockUnsteadyResidualEvaluator()
+    num_dirs = 3
+    fom_dirs = ["{tmp_path}/run_{i}" for i in range(num_dirs)]
+    fom_filename = "dummy"
+
+    res_snaps = evaluate_and_load_unsteady_residual_snapshots(residual_evaluator,fom_dirs,fom_filename,tmp_path)
+    
+    assert(res_snaps.shape == (3,10,num_dirs*5))
+
+    for i in range(num_dirs):
+        assert(os.path.isdir(f'{tmp_path}/res_' + str(i)))
+
+if __name__ == "__main__":
+    test_steady_residual_evaluator()
+    test_unsteady_residual_evaluator()

--- a/tests/romtools/workflows/test_residual_evaluator.py
+++ b/tests/romtools/workflows/test_residual_evaluator.py
@@ -9,17 +9,17 @@ class MockSteadyResidualEvaluator:
     def __init__(self):
         pass
 
-    def load_projected_full_solution(self, filename: str) -> np.ndarray:
+    def compute_reduced_state(self, filename: str) -> np.ndarray:
         return np.zeros((3,4))
 
-    def evaluate_full_residual(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
-        return np.zeros((3,10))
+    def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray) -> np.ndarray:
+        return np.zeros((3,10,1))
                       
 class MockUnsteadyResidualEvaluator:
     def __init__(self):
         pass
 
-    def load_projected_full_solutions(self, filename: str) -> (np.ndarray,np.ndarray):
+    def compute_reduced_states(self, filename: str) -> (np.ndarray,np.ndarray):
         return np.zeros((3,4,5)),np.ones(5)
     
     def evaluate_full_residuals(self, run_directory: str, full_model_directory: str, reduced_states: np.ndarray, times: np.ndarray) -> (np.ndarray):

--- a/tests/romtools/workflows/test_residual_evaluator.py
+++ b/tests/romtools/workflows/test_residual_evaluator.py
@@ -9,7 +9,7 @@ class MockSteadyResidualEvaluator:
     def __init__(self):
         pass
 
-    def compute_reduced_state(self, filename: str) -> np.ndarray:
+    def compute_reduced_states(self, filename: str) -> np.ndarray:
         return np.zeros((3, 4))
 
     def evaluate_full_residuals(
@@ -26,8 +26,11 @@ class MockUnsteadyResidualEvaluator:
     def __init__(self):
         pass
 
-    def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
-        return np.zeros((4, 5)), np.ones(5)
+    def compute_reduced_states(self, filename: str) -> np.ndarray:
+        return np.zeros((4, 5))
+    
+    def get_times(self,filename: str) -> np.ndarray:
+        return np.ones(5)
 
     def evaluate_full_residuals(
         self,
@@ -44,8 +47,11 @@ class MockUnsteadyResidualEvaluatorNonSequentialTemporalData:
     def __init__(self):
         pass
 
-    def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
-        return np.zeros((4, 5, 2)), np.ones((5, 2))
+    def compute_reduced_states(self, filename: str) -> np.ndarray:
+        return np.zeros((4, 5, 2))
+    
+    def get_times(self,filename: str) -> np.ndarray:
+        return np.ones((5, 2))
 
     def evaluate_full_residuals(
         self,

--- a/tests/romtools/workflows/test_residual_evaluator.py
+++ b/tests/romtools/workflows/test_residual_evaluator.py
@@ -13,7 +13,11 @@ class MockSteadyResidualEvaluator:
         return np.zeros((3, 4))
 
     def evaluate_full_residuals(
-        self, run_directory: str, full_model_directory: str, reduced_state: np.ndarray
+        self,
+        run_directory: str,
+        full_model_directory: str,
+        reduced_state: np.ndarray,
+        parameter_sample: dict,
     ) -> np.ndarray:
         return np.zeros((3, 10, 1))
 
@@ -23,13 +27,32 @@ class MockUnsteadyResidualEvaluator:
         pass
 
     def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
-        return np.zeros((3, 4, 5)), np.ones(5)
+        return np.zeros((4, 5)), np.ones(5)
 
     def evaluate_full_residuals(
         self,
         run_directory: str,
         full_model_directory: str,
         reduced_states: np.ndarray,
+        parameter_sample: dict,
+        times: np.ndarray,
+    ) -> np.ndarray:
+        return np.zeros((3, 10, 5))
+
+
+class MockUnsteadyResidualEvaluatorNonSequentialTemporalData:
+    def __init__(self):
+        pass
+
+    def compute_reduced_states(self, filename: str) -> (np.ndarray, np.ndarray):
+        return np.zeros((4, 5, 2)), np.ones((5, 2))
+
+    def evaluate_full_residuals(
+        self,
+        run_directory: str,
+        full_model_directory: str,
+        reduced_states: np.ndarray,
+        parameter_sample: dict,
         times: np.ndarray,
     ) -> np.ndarray:
         return np.zeros((3, 10, 5))
@@ -75,6 +98,27 @@ def test_unsteady_residual_evaluator(tmp_path):
         assert os.path.isdir(f"{tmp_path}/res_" + str(i))
 
 
+@pytest.mark.mpi_skip
+def test_unsteady_residual_evaluator_nonsequential_temporal_data(tmp_path):
+    # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
+    print("\n", tmp_path)
+
+    residual_evaluator = MockUnsteadyResidualEvaluatorNonSequentialTemporalData()
+    num_dirs = 3
+    fom_dirs = ["{tmp_path}/run_{i}" for i in range(num_dirs)]
+    fom_filename = "dummy"
+
+    res_snaps = evaluate_and_load_unsteady_residual_snapshots(
+        residual_evaluator, fom_dirs, fom_filename, tmp_path
+    )
+
+    assert res_snaps.shape == (3, 10, num_dirs * 5)
+
+    for i in range(num_dirs):
+        assert os.path.isdir(f"{tmp_path}/res_" + str(i))
+
+
 if __name__ == "__main__":
-    test_steady_residual_evaluator()
-    test_unsteady_residual_evaluator()
+    test_steady_residual_evaluator(".")
+    test_unsteady_residual_evaluator(".")
+    test_unsteady_residual_evaluator_nonsequential_temporal_data(".")


### PR DESCRIPTION
Add support for workflows to generate residual snapshots needed for hyper-reduction:

- Samplers now return a list of run directories for FOM cases
- The residual evaluator can take this list of directories and a trial space, then issue commands to project FOM snapshots, compute the corresponding residuals, and save them to disk.

I have added some simple tests and tried this out with aria-tools. 