### PR TITLE
170 add training workflow using a basic holdout set

### DIFF
--- a/romtools/hyper_reduction/deim.py
+++ b/romtools/hyper_reduction/deim.py
@@ -230,29 +230,3 @@ def multi_state_deim_get_indices(U):
         indices = deim_get_indices(data_matrix)
         all_indices = np.unique(np.append(all_indices, indices))
     return all_indices
-
-
-def deim_get_indices(U):
-    """
-    Implementation of the discrete empirical method as described in Algorithm 1 of
-    S. Chaturantabut and D. C. Sorensen, "Discrete Empirical Interpolation for
-    nonlinear model reduction," doi: 10.1109/CDC.2009.5400045.
-
-    Args:
-        $\\mathbf{U} \\in \\mathbb{R}^{m \\times n}$, where m is the number of DOFs and n the number of samples. Function basis in matrix format
-
-    Returns:
-        $\\mathrm{indices} \\in \\mathbb{I}^{n}$: sample mesh indices
-    """
-
-    m = np.shape(U)[1]
-    first_index = np.argmax(np.abs(U[:, 0]))
-    indices = first_index
-    for ell in range(1, m):
-        LHS = U[indices, 0:ell]
-        RHS = U[indices, ell]
-        if ell == 1:
-            LHS = np.ones((1, 1)) * LHS
-            RHS = np.ones(1) * RHS
-        C = np.linalg.solve(LHS, RHS)
-

--- a/romtools/hyper_reduction/deim.py
+++ b/romtools/hyper_reduction/deim.py
@@ -43,12 +43,13 @@
 # ************************************************************************
 #
 
-'''Implementation of DEIM technique for hyper-reduction'''
+"""Implementation of DEIM technique for hyper-reduction"""
 
 import numpy as np
 
+
 def deim_get_approximation_matrix(function_basis, sample_indices):
-    '''
+    """
     Given a function basis $\\mathbf{U}$ and sample indices defining $\\mathbf{P}$, we compute
     $$ \\mathbf{U} \\mathrm{pinv}( \\mathbf{P}^T \\mathbf{U})$$
     which comprises the matrix needed for the DEIM approximation to $\\mathbf{f}$
@@ -59,14 +60,15 @@ def deim_get_approximation_matrix(function_basis, sample_indices):
 
     Returns:
         deim_matrix: (n,$n_s$) array. DEIM approximation basis
-    '''
+    """
     sampled_function_basis = function_basis[sample_indices]
     PU_pinv = np.linalg.pinv(sampled_function_basis)
     deim_matrix = function_basis @ PU_pinv
     return deim_matrix
 
+
 def multi_state_deim_get_test_basis(test_basis, function_basis, sample_indices):
-    '''
+    """
     For multistate systems. Constructs an independent DEIM basis for each state variable using uniform sample indices
     Args:
         test_basis: (n_var,m,k) array, n_var is the number of state variables,  m is the number of DOFs and k the number of basis functions. Test basis in projection scheme
@@ -76,18 +78,22 @@ def multi_state_deim_get_test_basis(test_basis, function_basis, sample_indices):
     Returns:
         deim_test_basis: (n_var,n_s,k) array, where n_var is the number of state variables, $n_s$ is the number of sample points and k the number of basis functions. DEIM test basis matrix.
 
-    '''
+    """
     n_var = function_basis.shape[0]
-    deim_test_basis = deim_get_test_basis(test_basis[0], function_basis[0], sample_indices)
+    deim_test_basis = deim_get_test_basis(
+        test_basis[0], function_basis[0], sample_indices
+    )
     deim_test_basis = deim_test_basis[None]
     for i in range(1, n_var):
-        deim_test_basis_i = deim_get_test_basis(test_basis[i], function_basis[i], sample_indices)
+        deim_test_basis_i = deim_get_test_basis(
+            test_basis[i], function_basis[i], sample_indices
+        )
         deim_test_basis = np.append(deim_test_basis, deim_test_basis_i[None], axis=0)
     return deim_test_basis
 
 
 def deim_get_test_basis(test_basis, function_basis, sample_indices):
-    '''
+    """
     Given a test basis $\\mathbf{\\Phi}$, a function basis $\\mathbf{U}$, and
     sample indices defining $\\mathbf{P}$, we compute
     $$[ \\mathbf{\Phi}^T \\mathbf{U} \\mathrm{pinv}( \\mathbf{P}^T \\mathbf{U}) ]^T$$
@@ -102,14 +108,15 @@ def deim_get_test_basis(test_basis, function_basis, sample_indices):
     Returns:
         deim_test_basis: (n_s,k) array, where $n_s$ is the number of sample points and k the number of basis functions. DEIM test basis matrix.
 
-    '''
+    """
     sampled_function_basis = function_basis[sample_indices]
     PU_pinv = np.linalg.pinv(sampled_function_basis)
     deim_test_basis = (test_basis.transpose() @ function_basis) @ PU_pinv
     return deim_test_basis.transpose()
 
+
 def multi_state_deim_get_indices(U):
-    '''
+    """
     Version of DEIM for multi-state systems.
 
     We perform DEIM on each state variable, and
@@ -123,7 +130,7 @@ def multi_state_deim_get_indices(U):
     Returns:
          $\\mathrm{indices} \\in \\mathbb{I}^{n}$: sample mesh indices
 
-    '''
+    """
     all_indices = np.zeros(0, dtype=int)
     n_var = U.shape[0]
     for i in range(0, n_var):
@@ -134,7 +141,7 @@ def multi_state_deim_get_indices(U):
 
 
 def deim_get_indices(U):
-    '''
+    """
     Implementation of the discrete empirical method as described in Algorithm 1 of
     S. Chaturantabut and D. C. Sorensen, "Discrete Empirical Interpolation for
     nonlinear model reduction," doi: 10.1109/CDC.2009.5400045.
@@ -144,7 +151,7 @@ def deim_get_indices(U):
 
     Returns:
         $\\mathrm{indices} \\in \\mathbb{I}^{n}$: sample mesh indices
-    '''
+    """
 
     m = np.shape(U)[1]
     first_index = np.argmax(np.abs(U[:, 0]))
@@ -153,8 +160,8 @@ def deim_get_indices(U):
         LHS = U[indices, 0:ell]
         RHS = U[indices, ell]
         if ell == 1:
-            LHS = np.ones((1, 1))*LHS
-            RHS = np.ones(1)*RHS
+            LHS = np.ones((1, 1)) * LHS
+            RHS = np.ones(1) * RHS
         C = np.linalg.solve(LHS, RHS)
 
         residual = U[:, ell] - U[:, 0:ell] @ C

--- a/romtools/hyper_reduction/ecsw.py
+++ b/romtools/hyper_reduction/ecsw.py
@@ -43,7 +43,7 @@
 # ************************************************************************
 #
 
-'''
+"""
 Implementation of Energy-conserving sampling and weighting (ECSW)hyper-reduction
 
 Energy-conserving sampling and weighting (ECSW) is a hyper-reduction approach
@@ -73,7 +73,7 @@ For more details, consult Chapman et al. 2016 DOI: 10.1002/nme.5332.
 
 The ECSW class contains the methods needed to compute sampling indices and
 weights given a set of residual snapshot and trial basis data.
-'''
+"""
 
 import sys
 import abc
@@ -83,18 +83,19 @@ import romtools.linalg.linalg as la
 
 
 class ECSWsolver(abc.ABC):
-    '''
+    """
     Abstract base class for ECSW solvers
 
-    ECSW solvers should take in a linear system constructed from projected residual vector 
-    snapshots and the contributions at each mesh degree of freedom to the projected snapshot. 
+    ECSW solvers should take in a linear system constructed from projected residual vector
+    snapshots and the contributions at each mesh degree of freedom to the projected snapshot.
     The solvers should return arrays with sample mesh indices and weights.
 
     Methods:
-    '''
+    """
+
     @abc.abstractmethod
     def __init__(self, solver_param_dict: dict = None):
-        '''
+        """
         Set solver parameters to non-default values
 
         Args:
@@ -103,16 +104,18 @@ class ECSWsolver(abc.ABC):
             max_non_neg_iters: int, maximum inner iterations to enforce non-negativity
             max_iters_res_unchanged: int, maximum number of iterations without any change in the residual norm before terminating
             zero_tol: int, tolerance used to check if weights or residual norm changes are near zero
-        '''
+        """
         pass
 
     @abc.abstractmethod
-    def __call__(self, full_mesh_lhs: np.ndarray, full_mesh_rhs: np.array, tolerance: np.double) -> Tuple[np.ndarray, np.ndarray]:
-        '''
+    def __call__(
+        self, full_mesh_lhs: np.ndarray, full_mesh_rhs: np.array, tolerance: np.double
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
         Compute the sample mesh DoF indices and corresponding weights
 
         Args:
-            full_mesh_lhs: (n_snap*n_rom, n_dof) numpy ndarray, where n_snap is the number of residual snapshots, n_rom is the ROM dimension, 
+            full_mesh_lhs: (n_snap*n_rom, n_dof) numpy ndarray, where n_snap is the number of residual snapshots, n_rom is the ROM dimension,
             and n_dof is the number of mesh degrees of freedom (DoFs) (nodes, volumes, or elements)
             full_mesh_rhs: (n_snap*n_rom,) numpy array
             tolerance: Double, the ECSW tolerance parameter. Lower values of tolerance will result in more mesh DoF samples
@@ -122,8 +125,9 @@ class ECSWsolver(abc.ABC):
             First array: (n_dof_sample_mesh,) numpy ndarray of ints, the mesh indices in the sample mesh.
             Second array: (n_dof_sample_mesh,) numpy ndarray of doubles, the corresponding sample mesh weights.
 
-        '''
+        """
         pass
+
 
 # ecsw non-negative least-squares class
 # TODO: scipy loss and enhancement method for testing? Won't work in place of
@@ -131,30 +135,36 @@ class ECSWsolver(abc.ABC):
 
 
 class ECSWsolverNNLS(ECSWsolver):
-    '''
+    """
     Given a linear system with left-hand side full_mesh_lhs and right-hand side full_mesh_rhs compute sample mesh indices and weights for ECSW using the non-negative least squares algorithm from Chapman et al. 2016
     DOI: 10.1002/nme.5332.
-    '''
+    """
 
     def __init__(self, solver_param_dict: dict = None):
         # Set default solver parameter values
         self.max_iters = 10000  # maximum overall iterations
-        self.max_non_neg_iters = 100  # maximum inner iterations to enforce non-negativity
+        self.max_non_neg_iters = (
+            100  # maximum inner iterations to enforce non-negativity
+        )
         self.max_iters_res_unchanged = 10  # maximum number of iterations without any change in residual before terminating
         self.zero_tol = 1e-12  # tolerance used to check if weights or residual norm changes are near zero
 
         if solver_param_dict is not None:
-            if 'max_iters' in solver_param_dict.keys():
-                self.max_iters = solver_param_dict['max_iters']
-            if 'max_non_neg_iters' in solver_param_dict.keys():
-                self.max_non_neg_iters = solver_param_dict['max_non_neg_iters']
-            if 'max_iters_res_unchanged' in solver_param_dict.keys():
-                self.max_iters_res_unchanged = solver_param_dict['max_iters_res_unchanged']
-            if 'zero_tol' in solver_param_dict.keys():
-                self.zero_tol = solver_param_dict['zero_tol']
+            if "max_iters" in solver_param_dict.keys():
+                self.max_iters = solver_param_dict["max_iters"]
+            if "max_non_neg_iters" in solver_param_dict.keys():
+                self.max_non_neg_iters = solver_param_dict["max_non_neg_iters"]
+            if "max_iters_res_unchanged" in solver_param_dict.keys():
+                self.max_iters_res_unchanged = solver_param_dict[
+                    "max_iters_res_unchanged"
+                ]
+            if "zero_tol" in solver_param_dict.keys():
+                self.zero_tol = solver_param_dict["zero_tol"]
 
-    def __call__(self, full_mesh_lhs: np.ndarray, full_mesh_rhs: np.array, tolerance: np.double):
-        '''
+    def __call__(
+        self, full_mesh_lhs: np.ndarray, full_mesh_rhs: np.array, tolerance: np.double
+    ):
+        """
         Compute the sample mesh DoF indices and corresponding weights using the non-negative least squares algorithm from Chapman et al. 2016
         DOI: 10.1002/nme.5332.
 
@@ -170,7 +180,7 @@ class ECSWsolverNNLS(ECSWsolver):
             First array: (n_dof_sample_mesh,) numpy ndarray of ints, the mesh indices in the sample mesh.
             Second array: (n_dof_sample_mesh,) numpy ndarray of doubles, the corresponding sample mesh weights.
 
-        '''
+        """
 
         n_dof = full_mesh_lhs.shape[1]
 
@@ -179,7 +189,7 @@ class ECSWsolverNNLS(ECSWsolver):
         sample_mesh_indicies = []
         residual = full_mesh_rhs.copy()
         residual_norm = np.linalg.norm(residual)
-        target_norm = tolerance*residual_norm
+        target_norm = tolerance * residual_norm
 
         full_mesh_weights = np.zeros(n_dof)
         full_mesh_candidate_weights = np.zeros(n_dof)
@@ -187,13 +197,17 @@ class ECSWsolverNNLS(ECSWsolver):
         residual_norm_unchanged = 0
 
         # add nodes to sample mesh until tolerance is met
-        while (residual_norm > target_norm) and (residual_norm_unchanged < self.max_iters_res_unchanged) and (iters < self.max_iters):
+        while (
+            (residual_norm > target_norm)
+            and (residual_norm_unchanged < self.max_iters_res_unchanged)
+            and (iters < self.max_iters)
+        ):
             # determine new node to add to sample mesh
             weighted_residual = np.dot(full_mesh_lhs.T, residual)
 
             # make sure mesh entity hasn't already been selected
             still_searching = True
-            if (len(sample_mesh_indicies) == n_dof):
+            if len(sample_mesh_indicies) == n_dof:
                 still_searching = False
             while still_searching:
                 mesh_index = np.argmax(weighted_residual)
@@ -201,53 +215,82 @@ class ECSWsolverNNLS(ECSWsolver):
                 if mesh_index in sample_mesh_indicies:
                     still_searching = True
                     weighted_residual[mesh_index] = la.min(weighted_residual)
-                    if np.all((weighted_residual-weighted_residual[mesh_index])<1e-15):
+                    if np.all(
+                        (weighted_residual - weighted_residual[mesh_index]) < 1e-15
+                    ):
                         # All elements are the same, select random element outside of sample mesh
-                        unselected_indicies = np.setdiff1d(np.arange(n_dof),sample_mesh_indicies,assume_unique=True)
+                        unselected_indicies = np.setdiff1d(
+                            np.arange(n_dof), sample_mesh_indicies, assume_unique=True
+                        )
                         mesh_index = unselected_indicies[0]
                         still_searching = False
 
-
             # add new mesh entity index
-            if (len(sample_mesh_indicies) < n_dof):
+            if len(sample_mesh_indicies) < n_dof:
                 sample_mesh_indicies.append(mesh_index)
 
-            print("iteration={}  sample mesh size={}  residual norm={:.8e}  ratio to target={:.8e} ".format(iters, len(sample_mesh_indicies), residual_norm, residual_norm/target_norm))
+            print(
+                "iteration={}  sample mesh size={}  residual norm={:.8e}  ratio to target={:.8e} ".format(
+                    iters,
+                    len(sample_mesh_indicies),
+                    residual_norm,
+                    residual_norm / target_norm,
+                )
+            )
             iters += 1
 
             # compute corresponding weights
 
             for j in range(self.max_non_neg_iters):
                 sample_mesh_lhs = full_mesh_lhs[:, sample_mesh_indicies]
-                sample_mesh_candidate_weights = np.dot(np.linalg.pinv(sample_mesh_lhs), full_mesh_rhs)
+                sample_mesh_candidate_weights = np.dot(
+                    np.linalg.pinv(sample_mesh_lhs), full_mesh_rhs
+                )
                 full_mesh_candidate_weights *= 0
-                full_mesh_candidate_weights[sample_mesh_indicies] = sample_mesh_candidate_weights
+                full_mesh_candidate_weights[sample_mesh_indicies] = (
+                    sample_mesh_candidate_weights
+                )
                 if np.all(sample_mesh_candidate_weights > 0):
                     full_mesh_weights = full_mesh_candidate_weights.copy()
                     break
                 # line search to enforce non-negativity
-                max_step = self.__max_feasible_step(full_mesh_weights[sample_mesh_indicies], sample_mesh_candidate_weights)
-                full_mesh_weights_new = full_mesh_weights + max_step * (full_mesh_candidate_weights - full_mesh_weights)
+                max_step = self.__max_feasible_step(
+                    full_mesh_weights[sample_mesh_indicies],
+                    sample_mesh_candidate_weights,
+                )
+                full_mesh_weights_new = full_mesh_weights + max_step * (
+                    full_mesh_candidate_weights - full_mesh_weights
+                )
 
                 # remove zero valued indices
-                near_zero_inds = np.nonzero(full_mesh_weights_new[sample_mesh_indicies] < self.zero_tol)[0]
-                samp_inds_for_removal = [sample_mesh_indicies[i] for i in near_zero_inds]
+                near_zero_inds = np.nonzero(
+                    full_mesh_weights_new[sample_mesh_indicies] < self.zero_tol
+                )[0]
+                samp_inds_for_removal = [
+                    sample_mesh_indicies[i] for i in near_zero_inds
+                ]
                 for samp_ind in samp_inds_for_removal:
                     sample_mesh_indicies.remove(samp_ind)
 
                 # increment iteration count
-                print("iteration={}  sample mesh size={}  residual norm={:.8e}  ratio to target={:.8e} ".format(iters, len(sample_mesh_indicies), residual_norm, residual_norm/target_norm))
+                print(
+                    "iteration={}  sample mesh size={}  residual norm={:.8e}  ratio to target={:.8e} ".format(
+                        iters,
+                        len(sample_mesh_indicies),
+                        residual_norm,
+                        residual_norm / target_norm,
+                    )
+                )
                 iters += 1
-                full_mesh_weights = 1*full_mesh_weights_new
+                full_mesh_weights = 1 * full_mesh_weights_new
 
-
-            if j == self.max_non_neg_iters-1:
+            if j == self.max_non_neg_iters - 1:
                 sys.exit("Error: NNLS algorithm failed to compute weights")
 
             # update least-squares residual
             sample_mesh_weights = full_mesh_weights[sample_mesh_indicies]
             residual = full_mesh_rhs - np.dot(sample_mesh_lhs, sample_mesh_weights)
-            residul_old_norm = 1*residual_norm
+            residul_old_norm = 1 * residual_norm
             residual_norm = np.linalg.norm(residual)
 
             if np.abs(residual_norm - residul_old_norm) < self.zero_tol:
@@ -255,16 +298,27 @@ class ECSWsolverNNLS(ECSWsolver):
             else:
                 residual_norm_unchanged = 0
 
-            if (residual_norm_unchanged >= self.max_iters_res_unchanged):
-                print("WARNING: Norm has not changed more than {} in {} steps, exiting NNLS".format(self.zero_tol, self.max_iters_res_unchanged))
+            if residual_norm_unchanged >= self.max_iters_res_unchanged:
+                print(
+                    "WARNING: Norm has not changed more than {} in {} steps, exiting NNLS".format(
+                        self.zero_tol, self.max_iters_res_unchanged
+                    )
+                )
 
         print("NNLS complete! Final stats:")
-        print("iteration={}  sample mesh size={}  residual norm={:.8e}  ratio to target={:.8e} ".format(iters, len(sample_mesh_indicies), residual_norm, residual_norm/target_norm))
+        print(
+            "iteration={}  sample mesh size={}  residual norm={:.8e}  ratio to target={:.8e} ".format(
+                iters,
+                len(sample_mesh_indicies),
+                residual_norm,
+                residual_norm / target_norm,
+            )
+        )
 
-        return np.array(sample_mesh_indicies,dtype=int), sample_mesh_weights
+        return np.array(sample_mesh_indicies, dtype=int), sample_mesh_weights
 
     def __max_feasible_step(self, weights, candidate_weights):
-        '''
+        """
         determine maximum update step size such that:
         weights + step_size * (candidate_weights-weights) >=0
 
@@ -274,11 +328,11 @@ class ECSWsolverNNLS(ECSWsolver):
 
         Returns:
             step_size: double
-        '''
+        """
         inds = np.argwhere(candidate_weights <= 0)
         step_size = 1.0
         for i in inds:
-            if (weights[i] == 0.0):
+            if weights[i] == 0.0:
                 step_size = 0
             else:
                 step_size_i = weights[i] / (weights[i] - candidate_weights[i])
@@ -288,10 +342,11 @@ class ECSWsolverNNLS(ECSWsolver):
 
 # ESCW helper functions for specific test basis types
 
-def _construct_linear_system(residual_snapshots: np.ndarray,
-                             test_basis: np.ndarray,
-                             n_var: int):
-    '''
+
+def _construct_linear_system(
+    residual_snapshots: np.ndarray, test_basis: np.ndarray, n_var: int
+):
+    """
     Construct the linear system required for ECSW with a fixed test basis, such as POD-Galerkin projection.
 
     Args:
@@ -302,22 +357,24 @@ def _construct_linear_system(residual_snapshots: np.ndarray,
     Returns:
         full_mesh_lhs: (n_snap*n_mode, n_dof) numpy ndarray, the left-hand side of the linear system required by the ECSW solver
         full_mesh_rhs: (n_snap*n_rom,) numpy array, the right-hand side of the linear system required by the ECSW solver
-    '''
+    """
 
     (n_var, n_dof, n_snap) = residual_snapshots.shape
     (n_var_tb, n_dof_tb, n_mode) = test_basis.shape
-    assert(n_var == n_var_tb)
-    assert(n_dof == n_dof_tb)
+    assert n_var == n_var_tb
+    assert n_dof == n_dof_tb
     # construct ECSW system
-    full_mesh_lhs = np.zeros((n_snap*n_mode, n_dof))
+    full_mesh_lhs = np.zeros((n_snap * n_mode, n_dof))
 
     # left-hand side
     for i in range(n_dof):
         # should be projection of all variables for a given mesh DoF
-        phi_block = test_basis[:,i,:]  # n_var x n_mode
-        res_snaps_block = residual_snapshots[:,i,:]  # n_var x n_snap
-        full_mesh_lhs_block = np.dot(phi_block.T, res_snaps_block)  # n_modes x n_snaps matrix
-        full_mesh_lhs[:, i] = np.ravel(full_mesh_lhs_block, order='F')
+        phi_block = test_basis[:, i, :]  # n_var x n_mode
+        res_snaps_block = residual_snapshots[:, i, :]  # n_var x n_snap
+        full_mesh_lhs_block = np.dot(
+            phi_block.T, res_snaps_block
+        )  # n_modes x n_snaps matrix
+        full_mesh_lhs[:, i] = np.ravel(full_mesh_lhs_block, order="F")
 
     # right-hand-side
     full_mesh_rhs = np.sum(full_mesh_lhs, axis=1)
@@ -325,12 +382,14 @@ def _construct_linear_system(residual_snapshots: np.ndarray,
     return full_mesh_lhs, full_mesh_rhs
 
 
-def ecsw_fixed_test_basis(ecsw_solver: ECSWsolver,
-                          residual_snapshots: np.ndarray,
-                          test_basis: np.ndarray,
-                          n_var: int,
-                          tolerance: np.double):
-    '''
+def ecsw_fixed_test_basis(
+    ecsw_solver: ECSWsolver,
+    residual_snapshots: np.ndarray,
+    test_basis: np.ndarray,
+    n_var: int,
+    tolerance: np.double,
+):
+    """
     ECSW implementation for a fixed test basis, such as POD-Galerkin projection
 
     Args:
@@ -344,20 +403,23 @@ def ecsw_fixed_test_basis(ecsw_solver: ECSWsolver,
         Tuple of numpy ndarrays.
         First array: (n_dof_sample_mesh,) numpy ndarray of ints, the mesh indices in the sample mesh.
         Second array: (n_dof_sample_mesh,) numpy ndarray of doubles, the corresponding sample mesh weights.
-    '''
+    """
 
     # TODO need to incorporate residual scales here too, perhaps using scaler.py
-    full_mesh_lhs, full_mesh_rhs = _construct_linear_system(residual_snapshots,
-                                                            test_basis,
-                                                            n_var)
+    full_mesh_lhs, full_mesh_rhs = _construct_linear_system(
+        residual_snapshots, test_basis, n_var
+    )
 
     return ecsw_solver(full_mesh_lhs, full_mesh_rhs, tolerance)
 
-def ecsw_varying_test_basis(ecsw_solver: ECSWsolver,
-                            full_mesh_lhs: np.ndarray,
-                            full_mesh_rhs: np.ndarray,
-                            tolerance: np.double):
-    '''
+
+def ecsw_varying_test_basis(
+    ecsw_solver: ECSWsolver,
+    full_mesh_lhs: np.ndarray,
+    full_mesh_rhs: np.ndarray,
+    tolerance: np.double,
+):
+    """
     ECSW implementation for a varying test basis, such as Least-Squares Petrov-Galerkin projection
 
     Args:
@@ -370,7 +432,6 @@ def ecsw_varying_test_basis(ecsw_solver: ECSWsolver,
         Tuple of numpy ndarrays.
         First array: (n_dof_sample_mesh,) numpy ndarray of ints, the mesh indices in the sample mesh.
         Second array: (n_dof_sample_mesh,) numpy ndarray of doubles, the corresponding sample mesh weights.
-    '''
+    """
 
     return ecsw_solver(full_mesh_lhs, full_mesh_rhs, tolerance)
-

--- a/romtools/workflows/sampling_with_holdout/__init__.py
+++ b/romtools/workflows/sampling_with_holdout/__init__.py
@@ -43,11 +43,11 @@
 # ************************************************************************
 #
 
-'''
+"""
 Implementation of basic sampling workflow with a holdout set.
 Given a parameter space $\\mathcal{D}$, and a holdout set size N, 
 we run N FOM samples and then iteratively build up the ROM until
 the error in a QoI over the holdout set is below a specified tolerance. 
-'''
+"""
 
 from romtools.workflows.sampling_with_holdout.sampling_with_holdout import *

--- a/romtools/workflows/sampling_with_holdout/__init__.py
+++ b/romtools/workflows/sampling_with_holdout/__init__.py
@@ -1,0 +1,53 @@
+#
+# ************************************************************************
+#
+#                         ROM Tools and Workflows
+# Copyright 2019 National Technology & Engineering Solutions of Sandia,LLC
+#                              (NTESS)
+#
+# Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+#
+# ROM Tools and Workflows is licensed under BSD-3-Clause terms of use:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Questions? Contact Eric Parish (ejparis@sandia.gov)
+#
+# ************************************************************************
+#
+
+'''
+Implementation of basic sampling workflow with a holdout set.
+Given a parameter space $\\mathcal{D}$, and a holdout set size N, 
+we run N FOM samples and then iteratively build up the ROM until
+the error in a QoI over the holdout set is below a specified tolerance. 
+'''
+
+from romtools.workflows.sampling_with_holdout.sampling_with_holdout import *

--- a/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
+++ b/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
@@ -1,0 +1,180 @@
+#
+# ************************************************************************
+#
+#                         ROM Tools and Workflows
+# Copyright 2019 National Technology & Engineering Solutions of Sandia,LLC
+#                              (NTESS)
+#
+# Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+#
+# ROM Tools and Workflows is licensed under BSD-3-Clause terms of use:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Questions? Contact Eric Parish (ejparis@sandia.gov)
+#
+# ************************************************************************
+#
+
+import os
+import time
+import numpy as np
+
+from romtools.workflows.models import QoiModel
+from romtools.workflows.parameter_spaces import ParameterSpace
+from romtools.workflows.workflow_utils import create_empty_dir 
+from romtools.workflows.sampling import *
+from romtools.workflows.model_builders import QoiModelBuilder
+
+def _create_parameter_dict(parameter_names, parameter_values):
+    return dict(zip(parameter_names, parameter_values))
+
+def run_sampling_with_holdout(fom_model: QoiModel, 
+                 rom_model_builder: QoiModelBuilder,
+                 parameter_space: ParameterSpace,
+                 absolute_work_directory: str, 
+                 holdout_set_size: int = 5,
+                 max_number_of_rom_samples: int = 20,
+                 tolerance = 1e-5,
+                 random_seed: int = 1):
+    '''
+    Core algorithm
+    '''
+    sampling_directory = absolute_work_directory
+    create_empty_dir(sampling_directory)
+    offline_directory_prefix = 'offline_data'
+
+    run_directory_prefix = "run_"
+    sampling_file = open(f"{sampling_directory}/sampling_with_holdout_status.log", "w", encoding="utf-8")
+    sampling_file.write("Holdout sampling status \n")
+
+    np.random.seed(random_seed)
+
+    parameter_samples = parameter_space.generate_samples(holdout_set_size + max_number_of_rom_samples)
+    parameter_names = parameter_space.get_names()
+
+    holdout_sample_indices = range(holdout_set_size)
+    training_sample_indices = range(holdout_set_size, holdout_set_size+max_number_of_rom_samples)
+    holdout_samples = parameter_samples[holdout_sample_indices]
+    training_samples = parameter_samples[training_sample_indices]
+
+    # Setup FOM directories for holdout set and potential training runs
+    for sample_index, sample in enumerate(holdout_samples):
+        fom_run_directory =  f'{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}'
+        create_empty_dir(fom_run_directory)
+
+        parameter_dict = _create_parameter_dict(parameter_names, sample)
+        fom_model.populate_run_directory(fom_run_directory,parameter_dict)
+    
+    for sample_index, sample in enumerate(training_samples):
+        fom_run_directory =  f'{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}'
+        create_empty_dir(fom_run_directory)
+
+        parameter_dict = _create_parameter_dict(parameter_names, sample)
+        fom_model.populate_run_directory(fom_run_directory,parameter_dict)
+
+
+    # Run FOM samples to build holdout set.     
+    fom_qois_holdout_set = np.zeros(holdout_set_size)
+    sampling_file.write(f"Building holdout set \n")
+    for i in holdout_sample_indices:
+        sampling_file.write(f"Running holdout FOM sample {i} \n")
+        sample_index = i
+        parameter_dict = _create_parameter_dict(parameter_names,parameter_samples[sample_index])
+        fom_run_directory = f'{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}'
+        create_empty_dir(fom_run_directory)
+        fom_model.populate_run_directory(fom_run_directory,parameter_dict)
+        fom_model.run_model(fom_run_directory,parameter_dict)
+        fom_qoi = fom_model.compute_qoi(fom_run_directory,parameter_dict)
+        if i == 0:
+            fom_qois_holdout_set = fom_qoi[None]
+        else:
+            fom_qois_holdout_set = np.append(fom_qois_holdout_set,fom_qoi[None],axis=0)
+
+    # Create ROM bases
+    sampling_file.write(f"Beginning sampling procedure \n")
+
+    converged = False
+    training_dirs = []
+    training_params = []
+    trained_samples = []
+    rom_qois_holdout_set = np.zeros(holdout_set_size)
+    holdout_set_errs = np.array([])
+    sample_index = 0
+    while converged is False and sample_index < max_number_of_rom_samples:
+        # Initialize FOM to be run at training set sample
+        sampling_file.write(f"Holdout set iteration # {sample_index}\n")
+
+        parameter_dict = _create_parameter_dict(parameter_names,training_samples[sample_index])
+        fom_run_directory = f'{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}'
+        
+        # Run FOM at training parameter 
+        sampling_file.write(f"Running training FOM sample {sample_index} \n")
+        fom_model.run_model(fom_run_directory,parameter_dict)
+        
+        sampling_file.write(f"Adding training FOM sample {sample_index} to basis \n")
+        training_params.append(parameter_samples[sample_index])
+        training_dirs.append(fom_run_directory)
+        trained_samples.append(sample_index)
+        sampling_file.write(f"Parameter samples: \n {np.asarray(training_params)}\n")
+
+        # Add FOM sample to ROM basis
+        sampling_file.write(f"Constructing ROM iteration {sample_index} \n")
+        updated_offline_data_dir = f'{sampling_directory}/rom_iteration_{sample_index}/{offline_directory_prefix}/'
+        create_empty_dir(updated_offline_data_dir)
+        rom_model = rom_model_builder.build_from_training_dirs(updated_offline_data_dir,training_dirs)
+
+        # Evaluate ROM at holdout set and compute QOI errors
+        for holdout_sample_index in holdout_sample_indices:
+            sampling_file.write(f"  Running ROM at holdout sample {holdout_sample_index}\n")
+            rom_run_directory = f'{sampling_directory}/rom/{run_directory_prefix}{holdout_sample_index}'
+            
+            parameter_dict = _create_parameter_dict(parameter_names,parameter_samples[holdout_sample_index])
+            create_empty_dir(rom_run_directory)
+            rom_model.populate_run_directory(rom_run_directory,parameter_dict)
+            rom_model.run_model(rom_run_directory,parameter_dict)
+            rom_qois_holdout_set[holdout_sample_index] = rom_model.compute_qoi(rom_run_directory,parameter_dict)
+        
+        # If Max QOI error is less than tolerance, converged = True
+        holdout_set_err = np.linalg.norm(rom_qois_holdout_set - fom_qois_holdout_set,np.inf)
+        holdout_set_errs = np.append(holdout_set_errs, holdout_set_err)
+        if holdout_set_err < tolerance:
+            converged = True
+            print(f"Holdout sampling run converged with QoI error {holdout_set_err}\n")
+
+        sample_index += 1
+    if sample_index == max_number_of_rom_samples:
+        print("Warning: Max number of iterations reached for holdout sampling")
+
+    np.savez(f'{sampling_directory}/holdout_stats',
+                 holdout_set_errs=holdout_set_errs,
+                 trained_samples=trained_samples)
+
+    sampling_file.close()

--- a/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
+++ b/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
@@ -108,7 +108,6 @@ def run_sampling_with_holdout(
 
     # Setup FOM directories and run samples to build holdout set.
     t0 = time.time()
-    fom_qois_holdout_set = np.zeros(holdout_set_size)
     sampling_file.write(f"Building holdout set \n")
     for sample_index in holdout_sample_indices:
         sampling_file.write(f"Running holdout FOM sample {sample_index} \n")
@@ -130,7 +129,6 @@ def run_sampling_with_holdout(
             )
     fom_time += time.time() - t0
 
-    # Create ROM bases
     sampling_file.write(f"Beginning sampling procedure \n")
 
     converged = False

--- a/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
+++ b/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
@@ -98,16 +98,7 @@ def run_sampling_with_holdout(
     holdout_samples = parameter_samples[holdout_sample_indices]
     training_samples = parameter_samples[training_sample_indices]
 
-    # Setup FOM directories for holdout set and potential training runs
-    for sample_index, sample in enumerate(holdout_samples):
-        fom_run_directory = (
-            f"{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}"
-        )
-        create_empty_dir(fom_run_directory)
-
-        parameter_dict = _create_parameter_dict(parameter_names, sample)
-        fom_model.populate_run_directory(fom_run_directory, parameter_dict)
-
+    # Setup FOM directories for potential training runs
     for sample_index, sample in enumerate(training_samples):
         fom_run_directory = f"{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}"
         create_empty_dir(fom_run_directory)
@@ -115,13 +106,12 @@ def run_sampling_with_holdout(
         parameter_dict = _create_parameter_dict(parameter_names, sample)
         fom_model.populate_run_directory(fom_run_directory, parameter_dict)
 
-    # Run FOM samples to build holdout set.
+    # Setup FOM directories and run samples to build holdout set.
     t0 = time.time()
     fom_qois_holdout_set = np.zeros(holdout_set_size)
     sampling_file.write(f"Building holdout set \n")
-    for i in holdout_sample_indices:
-        sampling_file.write(f"Running holdout FOM sample {i} \n")
-        sample_index = i
+    for sample_index in holdout_sample_indices:
+        sampling_file.write(f"Running holdout FOM sample {sample_index} \n")
         parameter_dict = _create_parameter_dict(
             parameter_names, parameter_samples[sample_index]
         )
@@ -132,7 +122,7 @@ def run_sampling_with_holdout(
         fom_model.populate_run_directory(fom_run_directory, parameter_dict)
         fom_model.run_model(fom_run_directory, parameter_dict)
         fom_qoi = fom_model.compute_qoi(fom_run_directory, parameter_dict)
-        if i == 0:
+        if sample_index == 0:
             fom_qois_holdout_set = fom_qoi[None]
         else:
             fom_qois_holdout_set = np.append(

--- a/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
+++ b/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
@@ -49,78 +49,95 @@ import numpy as np
 
 from romtools.workflows.models import QoiModel
 from romtools.workflows.parameter_spaces import ParameterSpace
-from romtools.workflows.workflow_utils import create_empty_dir 
+from romtools.workflows.workflow_utils import create_empty_dir
 from romtools.workflows.sampling import *
 from romtools.workflows.model_builders import QoiModelBuilder
+
 
 def _create_parameter_dict(parameter_names, parameter_values):
     return dict(zip(parameter_names, parameter_values))
 
-def run_sampling_with_holdout(fom_model: QoiModel, 
-                 rom_model_builder: QoiModelBuilder,
-                 parameter_space: ParameterSpace,
-                 absolute_work_directory: str, 
-                 holdout_set_size: int = 5,
-                 max_number_of_rom_samples: int = 20,
-                 tolerance = 1e-5,
-                 random_seed: int = 1):
-    '''
+
+def run_sampling_with_holdout(
+    fom_model: QoiModel,
+    rom_model_builder: QoiModelBuilder,
+    parameter_space: ParameterSpace,
+    absolute_work_directory: str,
+    holdout_set_size: int = 5,
+    max_number_of_rom_samples: int = 20,
+    tolerance=1e-5,
+    random_seed: int = 1,
+):
+    """
     Core algorithm
-    '''
+    """
     sampling_directory = absolute_work_directory
     create_empty_dir(sampling_directory)
-    offline_directory_prefix = 'offline_data'
+    offline_directory_prefix = "offline_data"
 
     run_directory_prefix = "run_"
-    sampling_file = open(f"{sampling_directory}/sampling_with_holdout_status.log", "w", encoding="utf-8")
+    sampling_file = open(
+        f"{sampling_directory}/sampling_with_holdout_status.log", "w", encoding="utf-8"
+    )
     sampling_file.write("Holdout sampling status \n")
-    fom_time = 0.
-    rom_time = 0.
-    basis_time = 0.
+    fom_time = 0.0
+    rom_time = 0.0
+    basis_time = 0.0
 
     np.random.seed(random_seed)
 
-    parameter_samples = parameter_space.generate_samples(holdout_set_size + max_number_of_rom_samples)
+    parameter_samples = parameter_space.generate_samples(
+        holdout_set_size + max_number_of_rom_samples
+    )
     parameter_names = parameter_space.get_names()
 
     holdout_sample_indices = range(holdout_set_size)
-    training_sample_indices = range(holdout_set_size, holdout_set_size+max_number_of_rom_samples)
+    training_sample_indices = range(
+        holdout_set_size, holdout_set_size + max_number_of_rom_samples
+    )
     holdout_samples = parameter_samples[holdout_sample_indices]
     training_samples = parameter_samples[training_sample_indices]
 
     # Setup FOM directories for holdout set and potential training runs
     for sample_index, sample in enumerate(holdout_samples):
-        fom_run_directory =  f'{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}'
+        fom_run_directory = (
+            f"{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}"
+        )
         create_empty_dir(fom_run_directory)
 
         parameter_dict = _create_parameter_dict(parameter_names, sample)
-        fom_model.populate_run_directory(fom_run_directory,parameter_dict)
-    
+        fom_model.populate_run_directory(fom_run_directory, parameter_dict)
+
     for sample_index, sample in enumerate(training_samples):
-        fom_run_directory =  f'{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}'
+        fom_run_directory = f"{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}"
         create_empty_dir(fom_run_directory)
 
         parameter_dict = _create_parameter_dict(parameter_names, sample)
-        fom_model.populate_run_directory(fom_run_directory,parameter_dict)
+        fom_model.populate_run_directory(fom_run_directory, parameter_dict)
 
-
-    # Run FOM samples to build holdout set.     
+    # Run FOM samples to build holdout set.
     t0 = time.time()
     fom_qois_holdout_set = np.zeros(holdout_set_size)
     sampling_file.write(f"Building holdout set \n")
     for i in holdout_sample_indices:
         sampling_file.write(f"Running holdout FOM sample {i} \n")
         sample_index = i
-        parameter_dict = _create_parameter_dict(parameter_names,parameter_samples[sample_index])
-        fom_run_directory = f'{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}'
+        parameter_dict = _create_parameter_dict(
+            parameter_names, parameter_samples[sample_index]
+        )
+        fom_run_directory = (
+            f"{sampling_directory}/fom/holdout_set/{run_directory_prefix}{sample_index}"
+        )
         create_empty_dir(fom_run_directory)
-        fom_model.populate_run_directory(fom_run_directory,parameter_dict)
-        fom_model.run_model(fom_run_directory,parameter_dict)
-        fom_qoi = fom_model.compute_qoi(fom_run_directory,parameter_dict)
+        fom_model.populate_run_directory(fom_run_directory, parameter_dict)
+        fom_model.run_model(fom_run_directory, parameter_dict)
+        fom_qoi = fom_model.compute_qoi(fom_run_directory, parameter_dict)
         if i == 0:
             fom_qois_holdout_set = fom_qoi[None]
         else:
-            fom_qois_holdout_set = np.append(fom_qois_holdout_set,fom_qoi[None],axis=0)
+            fom_qois_holdout_set = np.append(
+                fom_qois_holdout_set, fom_qoi[None], axis=0
+            )
     fom_time += time.time() - t0
 
     # Create ROM bases
@@ -137,15 +154,17 @@ def run_sampling_with_holdout(fom_model: QoiModel,
         # Initialize FOM to be run at training set sample
         sampling_file.write(f"Holdout set iteration # {sample_index}\n")
 
-        parameter_dict = _create_parameter_dict(parameter_names,training_samples[sample_index])
-        fom_run_directory = f'{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}'
-        
-        # Run FOM at training parameter 
+        parameter_dict = _create_parameter_dict(
+            parameter_names, training_samples[sample_index]
+        )
+        fom_run_directory = f"{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}"
+
+        # Run FOM at training parameter
         t0 = time.time()
         sampling_file.write(f"Running training FOM sample {sample_index} \n")
-        fom_model.run_model(fom_run_directory,parameter_dict)
+        fom_model.run_model(fom_run_directory, parameter_dict)
         fom_time += time.time() - t0
-        
+
         sampling_file.write(f"Adding training FOM sample {sample_index} to basis \n")
         training_params.append(parameter_samples[sample_index])
         training_dirs.append(fom_run_directory)
@@ -155,26 +174,38 @@ def run_sampling_with_holdout(fom_model: QoiModel,
         # Add FOM sample to ROM basis
         t0 = time.time()
         sampling_file.write(f"Constructing ROM iteration {sample_index} \n")
-        updated_offline_data_dir = f'{sampling_directory}/rom_iteration_{sample_index}/{offline_directory_prefix}/'
+        updated_offline_data_dir = f"{sampling_directory}/rom_iteration_{sample_index}/{offline_directory_prefix}/"
         create_empty_dir(updated_offline_data_dir)
-        rom_model = rom_model_builder.build_from_training_dirs(updated_offline_data_dir,training_dirs)
+        rom_model = rom_model_builder.build_from_training_dirs(
+            updated_offline_data_dir, training_dirs
+        )
         basis_time += time.time() - t0
 
         # Evaluate ROM at holdout set and compute QOI errors
         t0 = time.time()
         for holdout_sample_index in holdout_sample_indices:
-            sampling_file.write(f"  Running ROM at holdout sample {holdout_sample_index}\n")
-            rom_run_directory = f'{sampling_directory}/rom/{run_directory_prefix}{holdout_sample_index}'
-            
-            parameter_dict = _create_parameter_dict(parameter_names,parameter_samples[holdout_sample_index])
+            sampling_file.write(
+                f"  Running ROM at holdout sample {holdout_sample_index}\n"
+            )
+            rom_run_directory = (
+                f"{sampling_directory}/rom/{run_directory_prefix}{holdout_sample_index}"
+            )
+
+            parameter_dict = _create_parameter_dict(
+                parameter_names, parameter_samples[holdout_sample_index]
+            )
             create_empty_dir(rom_run_directory)
-            rom_model.populate_run_directory(rom_run_directory,parameter_dict)
-            rom_model.run_model(rom_run_directory,parameter_dict)
-            rom_qois_holdout_set[holdout_sample_index] = rom_model.compute_qoi(rom_run_directory,parameter_dict)
+            rom_model.populate_run_directory(rom_run_directory, parameter_dict)
+            rom_model.run_model(rom_run_directory, parameter_dict)
+            rom_qois_holdout_set[holdout_sample_index] = rom_model.compute_qoi(
+                rom_run_directory, parameter_dict
+            )
         rom_time += time.time() - t0
 
         # If Max QOI error is less than tolerance, converged = True
-        holdout_set_err = np.linalg.norm(rom_qois_holdout_set - fom_qois_holdout_set,np.inf)
+        holdout_set_err = np.linalg.norm(
+            rom_qois_holdout_set - fom_qois_holdout_set, np.inf
+        )
         holdout_set_errs = np.append(holdout_set_errs, holdout_set_err)
         if holdout_set_err < tolerance:
             converged = True
@@ -184,11 +215,13 @@ def run_sampling_with_holdout(fom_model: QoiModel,
     if sample_index == max_number_of_rom_samples:
         print("Warning: Max number of iterations reached for holdout sampling")
 
-    np.savez(f'{sampling_directory}/holdout_stats',
-                 holdout_set_errs=holdout_set_errs,
-                 trained_samples=trained_samples,
-                 fom_time=fom_time,
-                 rom_time=rom_time,
-                 basis_time=basis_time)
+    np.savez(
+        f"{sampling_directory}/holdout_stats",
+        holdout_set_errs=holdout_set_errs,
+        trained_samples=trained_samples,
+        fom_time=fom_time,
+        rom_time=rom_time,
+        basis_time=basis_time,
+    )
 
     sampling_file.close()

--- a/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
+++ b/romtools/workflows/sampling_with_holdout/sampling_with_holdout.py
@@ -74,6 +74,9 @@ def run_sampling_with_holdout(fom_model: QoiModel,
     run_directory_prefix = "run_"
     sampling_file = open(f"{sampling_directory}/sampling_with_holdout_status.log", "w", encoding="utf-8")
     sampling_file.write("Holdout sampling status \n")
+    fom_time = 0.
+    rom_time = 0.
+    basis_time = 0.
 
     np.random.seed(random_seed)
 
@@ -102,6 +105,7 @@ def run_sampling_with_holdout(fom_model: QoiModel,
 
 
     # Run FOM samples to build holdout set.     
+    t0 = time.time()
     fom_qois_holdout_set = np.zeros(holdout_set_size)
     sampling_file.write(f"Building holdout set \n")
     for i in holdout_sample_indices:
@@ -117,6 +121,7 @@ def run_sampling_with_holdout(fom_model: QoiModel,
             fom_qois_holdout_set = fom_qoi[None]
         else:
             fom_qois_holdout_set = np.append(fom_qois_holdout_set,fom_qoi[None],axis=0)
+    fom_time += time.time() - t0
 
     # Create ROM bases
     sampling_file.write(f"Beginning sampling procedure \n")
@@ -136,8 +141,10 @@ def run_sampling_with_holdout(fom_model: QoiModel,
         fom_run_directory = f'{sampling_directory}/fom/training_set/{run_directory_prefix}{sample_index}'
         
         # Run FOM at training parameter 
+        t0 = time.time()
         sampling_file.write(f"Running training FOM sample {sample_index} \n")
         fom_model.run_model(fom_run_directory,parameter_dict)
+        fom_time += time.time() - t0
         
         sampling_file.write(f"Adding training FOM sample {sample_index} to basis \n")
         training_params.append(parameter_samples[sample_index])
@@ -146,12 +153,15 @@ def run_sampling_with_holdout(fom_model: QoiModel,
         sampling_file.write(f"Parameter samples: \n {np.asarray(training_params)}\n")
 
         # Add FOM sample to ROM basis
+        t0 = time.time()
         sampling_file.write(f"Constructing ROM iteration {sample_index} \n")
         updated_offline_data_dir = f'{sampling_directory}/rom_iteration_{sample_index}/{offline_directory_prefix}/'
         create_empty_dir(updated_offline_data_dir)
         rom_model = rom_model_builder.build_from_training_dirs(updated_offline_data_dir,training_dirs)
+        basis_time += time.time() - t0
 
         # Evaluate ROM at holdout set and compute QOI errors
+        t0 = time.time()
         for holdout_sample_index in holdout_sample_indices:
             sampling_file.write(f"  Running ROM at holdout sample {holdout_sample_index}\n")
             rom_run_directory = f'{sampling_directory}/rom/{run_directory_prefix}{holdout_sample_index}'
@@ -161,7 +171,8 @@ def run_sampling_with_holdout(fom_model: QoiModel,
             rom_model.populate_run_directory(rom_run_directory,parameter_dict)
             rom_model.run_model(rom_run_directory,parameter_dict)
             rom_qois_holdout_set[holdout_sample_index] = rom_model.compute_qoi(rom_run_directory,parameter_dict)
-        
+        rom_time += time.time() - t0
+
         # If Max QOI error is less than tolerance, converged = True
         holdout_set_err = np.linalg.norm(rom_qois_holdout_set - fom_qois_holdout_set,np.inf)
         holdout_set_errs = np.append(holdout_set_errs, holdout_set_err)
@@ -175,6 +186,9 @@ def run_sampling_with_holdout(fom_model: QoiModel,
 
     np.savez(f'{sampling_directory}/holdout_stats',
                  holdout_set_errs=holdout_set_errs,
-                 trained_samples=trained_samples)
+                 trained_samples=trained_samples,
+                 fom_time=fom_time,
+                 rom_time=rom_time,
+                 basis_time=basis_time)
 
     sampling_file.close()

--- a/tests/romtools/workflows/sampling_with_holdout/test_sampling_with_holdout.py
+++ b/tests/romtools/workflows/sampling_with_holdout/test_sampling_with_holdout.py
@@ -9,23 +9,25 @@ from romtools.workflows.parameter_spaces import MonteCarloSampler, UniformParame
 
 class MockFOMQoiModel:
     def __init__(self):
-        self.my_qois_ = np.array([1.,1.,1.,1.,1.,1.,1.,1.,1.,1.])
+        self.my_qois_ = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
         self.counter_ = 0
 
-    def populate_run_directory(self, run_dir,parameter_sample):
+    def populate_run_directory(self, run_dir, parameter_sample):
         os.chdir(run_dir)
         parameter_values = np.zeros(0)
         for parameter_name in list(parameter_sample.keys()):
-            parameter_values = np.append(parameter_values,parameter_sample[parameter_name])
-        np.savez('parameter_values.npz',parameter_values=parameter_values)
+            parameter_values = np.append(
+                parameter_values, parameter_sample[parameter_name]
+            )
+        np.savez("parameter_values.npz", parameter_values=parameter_values)
 
     def run_model(self, run_dir, parameter_sample):
         os.chdir(run_dir)
-        params_input = np.load('parameter_values.npz')['parameter_values']
-        for i in range(0,len(parameter_sample)):
-          parameter_name = list(parameter_sample.keys())[i]
-          assert(params_input[i] == parameter_sample[parameter_name])
-        np.savetxt('fom_succesful.dat',np.array([0]),'%i')
+        params_input = np.load("parameter_values.npz")["parameter_values"]
+        for i in range(0, len(parameter_sample)):
+            parameter_name = list(parameter_sample.keys())[i]
+            assert params_input[i] == parameter_sample[parameter_name]
+        np.savetxt("fom_succesful.dat", np.array([0]), "%i")
         return 0
 
     def compute_qoi(self, run_dir, parameter_sample):
@@ -33,41 +35,42 @@ class MockFOMQoiModel:
         return self.my_qois_[self.counter_ - 1]
 
 
-
-
 class MockQoiModelBuilder:
     def __init__(self):
         self.counter_ = 0
-        self.my_qois_ = np.array([1.4, 1.5, 1.3, 0.7, 1.1, 1.01, 1.0+1e-7])
+        self.my_qois_ = np.array([1.4, 1.5, 1.3, 0.7, 1.1, 1.01, 1.0 + 1e-7])
 
-    def build_from_training_dirs(self,offline_data_dir, training_data_dirs):
+    def build_from_training_dirs(self, offline_data_dir, training_data_dirs):
         rom_model = MockROMQoiModel(self.my_qois_[self.counter_])
-        np.savetxt(f'{offline_data_dir}/offline_data.dat',np.array([0]),'%i')
+        np.savetxt(f"{offline_data_dir}/offline_data.dat", np.array([0]), "%i")
         self.counter_ += 1
         return rom_model
-    
+
     def reset_counter(self):
         self.counter_ = 0
 
+
 class MockROMQoiModel:
-    def __init__(self,my_qoi):
+    def __init__(self, my_qoi):
         self.counter = 0
         self.my_qoi_ = my_qoi
 
-    def populate_run_directory(self, run_dir,parameter_sample):
+    def populate_run_directory(self, run_dir, parameter_sample):
         os.chdir(run_dir)
         parameter_values = np.zeros(0)
         for parameter_name in list(parameter_sample.keys()):
-            parameter_values = np.append(parameter_values,parameter_sample[parameter_name])
-        np.savez('parameter_values.npz',parameter_values=parameter_values)
+            parameter_values = np.append(
+                parameter_values, parameter_sample[parameter_name]
+            )
+        np.savez("parameter_values.npz", parameter_values=parameter_values)
 
     def run_model(self, run_dir, parameter_sample):
         os.chdir(run_dir)
-        params_input = np.load('parameter_values.npz')['parameter_values']
-        for i in range(0,len(parameter_sample)):
-          parameter_name = list(parameter_sample.keys())[i]
-          assert(params_input[i] == parameter_sample[parameter_name])
-        np.savetxt('passed.txt',np.array([0]),'%i')
+        params_input = np.load("parameter_values.npz")["parameter_values"]
+        for i in range(0, len(parameter_sample)):
+            parameter_name = list(parameter_sample.keys())[i]
+            assert params_input[i] == parameter_sample[parameter_name]
+        np.savetxt("passed.txt", np.array([0]), "%i")
         return 0
 
     def compute_qoi(self, run_directory: str, parameter_sample: dict) -> float:
@@ -79,63 +82,78 @@ def test_sampling_with_holdout(tmp_path):
     # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
     #   about tmp_path
     wdir = str(tmp_path)  # does not like posixpaths
-    print('\n', wdir)
+    print("\n", wdir)
 
     my_dir = os.path.realpath(os.path.dirname(__file__))
 
     QoiModel = MockFOMQoiModel()
     RomModelBuilder = MockQoiModelBuilder()
 
-    my_parameter_space = UniformParameterSpace(['u', 'v', 'w'],
-                                            np.array([0, 1, 2]),
-                                            np.array([1, 2, 3]),
-                                            sampler=MonteCarloSampler)
+    my_parameter_space = UniformParameterSpace(
+        ["u", "v", "w"],
+        np.array([0, 1, 2]),
+        np.array([1, 2, 3]),
+        sampler=MonteCarloSampler,
+    )
 
+    ## First, test that the routine will terminate if it hits the max iters
+    run_sampling_with_holdout(
+        QoiModel, RomModelBuilder, my_parameter_space, wdir, 4, 3, 1e-5, 1
+    )
 
-    ## First, test that the routine will terminate if it hits the max iters 
-    run_sampling_with_holdout(QoiModel, RomModelBuilder, my_parameter_space, wdir, 4, 3, 1e-5, 1)
-        
     # Ensure correct number of holdout set and training set FOMs are run
-    for sample in range(0,4):
-        assert os.path.isfile(f'{wdir}/fom/holdout_set/run_{sample}/fom_succesful.dat'), sample
-    for sample in range(0,2):
-        assert os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+    for sample in range(0, 4):
+        assert os.path.isfile(
+            f"{wdir}/fom/holdout_set/run_{sample}/fom_succesful.dat"
+        ), sample
+    for sample in range(0, 2):
+        assert os.path.isfile(
+            f"{wdir}/fom/training_set/run_{sample}/fom_succesful.dat"
+        ), sample
     for sample in range(3, 7):
-        assert not os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+        assert not os.path.isfile(
+            f"{wdir}/fom/training_set/run_{sample}/fom_succesful.dat"
+        ), sample
     # Check that right number of ROMs were created
-    for i in range(0,3):
-        assert os.path.isfile(f'{wdir}/rom_iteration_{i}/offline_data/offline_data.dat')
-    
-    holdout_output = np.load(f'{wdir}/holdout_stats.npz')
-    assert np.allclose(holdout_output['holdout_set_errs'],
-                       np.array([0.4, 0.5, 0.3]))
-    assert np.allclose(holdout_output['trained_samples'],
-                       np.array([0, 1, 2]))
-    
+    for i in range(0, 3):
+        assert os.path.isfile(f"{wdir}/rom_iteration_{i}/offline_data/offline_data.dat")
+
+    holdout_output = np.load(f"{wdir}/holdout_stats.npz")
+    assert np.allclose(holdout_output["holdout_set_errs"], np.array([0.4, 0.5, 0.3]))
+    assert np.allclose(holdout_output["trained_samples"], np.array([0, 1, 2]))
+
     ## Then, test that the method will terminate after reaching the error tolerance on the 7th iter
-    RomModelBuilder.reset_counter() # Reset mock ROM model QoI's
-    run_sampling_with_holdout(QoiModel, RomModelBuilder, my_parameter_space, wdir, 5, 20, 1e-5, 1)
-    
+    RomModelBuilder.reset_counter()  # Reset mock ROM model QoI's
+    run_sampling_with_holdout(
+        QoiModel, RomModelBuilder, my_parameter_space, wdir, 5, 20, 1e-5, 1
+    )
+
     # Ensure correct number of holdout set and training set FOMs are run
-    for sample in range(0,5):
-        assert os.path.isfile(f'{wdir}/fom/holdout_set/run_{sample}/fom_succesful.dat'), sample
-    for sample in range(0,7):
-        assert os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+    for sample in range(0, 5):
+        assert os.path.isfile(
+            f"{wdir}/fom/holdout_set/run_{sample}/fom_succesful.dat"
+        ), sample
+    for sample in range(0, 7):
+        assert os.path.isfile(
+            f"{wdir}/fom/training_set/run_{sample}/fom_succesful.dat"
+        ), sample
     for sample in range(7, 8):
-        assert not os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+        assert not os.path.isfile(
+            f"{wdir}/fom/training_set/run_{sample}/fom_succesful.dat"
+        ), sample
     # Check that right number of ROMs were created
-    for i in range(0,7):
-        assert os.path.isfile(f'{wdir}/rom_iteration_{i}/offline_data/offline_data.dat')
-    
-    holdout_output = np.load(f'{wdir}/holdout_stats.npz')
-    assert np.allclose(holdout_output['holdout_set_errs'],
-                       np.array([0.4, 0.5, 0.3, 0.3, 0.1, 0.01, 1e-7]))
-    assert np.allclose(holdout_output['trained_samples'],
-                       np.array([0, 1, 2, 3, 4, 5, 6]))
+    for i in range(0, 7):
+        assert os.path.isfile(f"{wdir}/rom_iteration_{i}/offline_data/offline_data.dat")
 
-
-
+    holdout_output = np.load(f"{wdir}/holdout_stats.npz")
+    assert np.allclose(
+        holdout_output["holdout_set_errs"],
+        np.array([0.4, 0.5, 0.3, 0.3, 0.1, 0.01, 1e-7]),
+    )
+    assert np.allclose(
+        holdout_output["trained_samples"], np.array([0, 1, 2, 3, 4, 5, 6])
+    )
 
 
 if __name__ == "__main__":
-    test_sampling_with_holdout(os.getcwd() + '/sampling_with_holdout_test_tmp/')
+    test_sampling_with_holdout(os.getcwd() + "/sampling_with_holdout_test_tmp/")

--- a/tests/romtools/workflows/sampling_with_holdout/test_sampling_with_holdout.py
+++ b/tests/romtools/workflows/sampling_with_holdout/test_sampling_with_holdout.py
@@ -109,6 +109,8 @@ def test_sampling_with_holdout(tmp_path):
     holdout_output = np.load(f'{wdir}/holdout_stats.npz')
     assert np.allclose(holdout_output['holdout_set_errs'],
                        np.array([0.4, 0.5, 0.3]))
+    assert np.allclose(holdout_output['trained_samples'],
+                       np.array([0, 1, 2]))
     
     ## Then, test that the method will terminate after reaching the error tolerance on the 7th iter
     RomModelBuilder.reset_counter() # Reset mock ROM model QoI's
@@ -128,6 +130,8 @@ def test_sampling_with_holdout(tmp_path):
     holdout_output = np.load(f'{wdir}/holdout_stats.npz')
     assert np.allclose(holdout_output['holdout_set_errs'],
                        np.array([0.4, 0.5, 0.3, 0.3, 0.1, 0.01, 1e-7]))
+    assert np.allclose(holdout_output['trained_samples'],
+                       np.array([0, 1, 2, 3, 4, 5, 6]))
 
 
 

--- a/tests/romtools/workflows/sampling_with_holdout/test_sampling_with_holdout.py
+++ b/tests/romtools/workflows/sampling_with_holdout/test_sampling_with_holdout.py
@@ -1,0 +1,137 @@
+import pytest
+import os
+import numpy as np
+from romtools.workflows.models import *
+from romtools.workflows.model_builders import *
+from romtools.workflows.sampling_with_holdout import run_sampling_with_holdout
+from romtools.workflows.parameter_spaces import MonteCarloSampler, UniformParameterSpace
+
+
+class MockFOMQoiModel:
+    def __init__(self):
+        self.my_qois_ = np.array([1.,1.,1.,1.,1.,1.,1.,1.,1.,1.])
+        self.counter_ = 0
+
+    def populate_run_directory(self, run_dir,parameter_sample):
+        os.chdir(run_dir)
+        parameter_values = np.zeros(0)
+        for parameter_name in list(parameter_sample.keys()):
+            parameter_values = np.append(parameter_values,parameter_sample[parameter_name])
+        np.savez('parameter_values.npz',parameter_values=parameter_values)
+
+    def run_model(self, run_dir, parameter_sample):
+        os.chdir(run_dir)
+        params_input = np.load('parameter_values.npz')['parameter_values']
+        for i in range(0,len(parameter_sample)):
+          parameter_name = list(parameter_sample.keys())[i]
+          assert(params_input[i] == parameter_sample[parameter_name])
+        np.savetxt('fom_succesful.dat',np.array([0]),'%i')
+        return 0
+
+    def compute_qoi(self, run_dir, parameter_sample):
+        self.counter_ += 1
+        return self.my_qois_[self.counter_ - 1]
+
+
+
+
+class MockQoiModelBuilder:
+    def __init__(self):
+        self.counter_ = 0
+        self.my_qois_ = np.array([1.4, 1.5, 1.3, 0.7, 1.1, 1.01, 1.0+1e-7])
+
+    def build_from_training_dirs(self,offline_data_dir, training_data_dirs):
+        rom_model = MockROMQoiModel(self.my_qois_[self.counter_])
+        np.savetxt(f'{offline_data_dir}/offline_data.dat',np.array([0]),'%i')
+        self.counter_ += 1
+        return rom_model
+    
+    def reset_counter(self):
+        self.counter_ = 0
+
+class MockROMQoiModel:
+    def __init__(self,my_qoi):
+        self.counter = 0
+        self.my_qoi_ = my_qoi
+
+    def populate_run_directory(self, run_dir,parameter_sample):
+        os.chdir(run_dir)
+        parameter_values = np.zeros(0)
+        for parameter_name in list(parameter_sample.keys()):
+            parameter_values = np.append(parameter_values,parameter_sample[parameter_name])
+        np.savez('parameter_values.npz',parameter_values=parameter_values)
+
+    def run_model(self, run_dir, parameter_sample):
+        os.chdir(run_dir)
+        params_input = np.load('parameter_values.npz')['parameter_values']
+        for i in range(0,len(parameter_sample)):
+          parameter_name = list(parameter_sample.keys())[i]
+          assert(params_input[i] == parameter_sample[parameter_name])
+        np.savetxt('passed.txt',np.array([0]),'%i')
+        return 0
+
+    def compute_qoi(self, run_directory: str, parameter_sample: dict) -> float:
+        return self.my_qoi_
+
+
+@pytest.mark.mpi_skip
+def test_sampling_with_holdout(tmp_path):
+    # see https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html for more info
+    #   about tmp_path
+    wdir = str(tmp_path)  # does not like posixpaths
+    print('\n', wdir)
+
+    my_dir = os.path.realpath(os.path.dirname(__file__))
+
+    QoiModel = MockFOMQoiModel()
+    RomModelBuilder = MockQoiModelBuilder()
+
+    my_parameter_space = UniformParameterSpace(['u', 'v', 'w'],
+                                            np.array([0, 1, 2]),
+                                            np.array([1, 2, 3]),
+                                            sampler=MonteCarloSampler)
+
+
+    ## First, test that the routine will terminate if it hits the max iters 
+    run_sampling_with_holdout(QoiModel, RomModelBuilder, my_parameter_space, wdir, 4, 3, 1e-5, 1)
+        
+    # Ensure correct number of holdout set and training set FOMs are run
+    for sample in range(0,4):
+        assert os.path.isfile(f'{wdir}/fom/holdout_set/run_{sample}/fom_succesful.dat'), sample
+    for sample in range(0,2):
+        assert os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+    for sample in range(3, 7):
+        assert not os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+    # Check that right number of ROMs were created
+    for i in range(0,3):
+        assert os.path.isfile(f'{wdir}/rom_iteration_{i}/offline_data/offline_data.dat')
+    
+    holdout_output = np.load(f'{wdir}/holdout_stats.npz')
+    assert np.allclose(holdout_output['holdout_set_errs'],
+                       np.array([0.4, 0.5, 0.3]))
+    
+    ## Then, test that the method will terminate after reaching the error tolerance on the 7th iter
+    RomModelBuilder.reset_counter() # Reset mock ROM model QoI's
+    run_sampling_with_holdout(QoiModel, RomModelBuilder, my_parameter_space, wdir, 5, 20, 1e-5, 1)
+    
+    # Ensure correct number of holdout set and training set FOMs are run
+    for sample in range(0,5):
+        assert os.path.isfile(f'{wdir}/fom/holdout_set/run_{sample}/fom_succesful.dat'), sample
+    for sample in range(0,7):
+        assert os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+    for sample in range(7, 8):
+        assert not os.path.isfile(f'{wdir}/fom/training_set/run_{sample}/fom_succesful.dat'), sample
+    # Check that right number of ROMs were created
+    for i in range(0,7):
+        assert os.path.isfile(f'{wdir}/rom_iteration_{i}/offline_data/offline_data.dat')
+    
+    holdout_output = np.load(f'{wdir}/holdout_stats.npz')
+    assert np.allclose(holdout_output['holdout_set_errs'],
+                       np.array([0.4, 0.5, 0.3, 0.3, 0.1, 0.01, 1e-7]))
+
+
+
+
+
+if __name__ == "__main__":
+    test_sampling_with_holdout(os.getcwd() + '/sampling_with_holdout_test_tmp/')


### PR DESCRIPTION
Simple holdout set implementation. First, n_hold FOM runs are used to build a holdout set. Then the routine iteratively builds up a basis by evaluating a FOM and adding the snapshot to the ROM basis until the QoI error between the ROM and the holdout set is below a certain tolerance or a maximum number of iterations are reached. 