### PR TITLE
203 ecsw improvements for lspg

### DIFF
--- a/romtools/hyper_reduction/ecsw.py
+++ b/romtools/hyper_reduction/ecsw.py
@@ -415,8 +415,9 @@ def ecsw_fixed_test_basis(
 
 def ecsw_varying_test_basis(
     ecsw_solver: ECSWsolver,
-    full_mesh_lhs: np.ndarray,
-    full_mesh_rhs: np.ndarray,
+    residual_snapshots: np.ndarray,
+    test_basis: np.ndarray,
+    n_var: int,
     tolerance: np.double,
 ):
     """
@@ -424,8 +425,9 @@ def ecsw_varying_test_basis(
 
     Args:
         ecsw_solver: ECSWsolver object corresponding to a child class with concrete implementations such as ECSWsolverNNLS.
-        full_mesh_lhs: (n_snap*n_rom, n_dof) numpy ndarray, where n_snap is the number of residual snapshots, n_rom is the ROM dimension, and n_dof is the number of mesh degrees of freedom (DoFs) (nodes, volumes, or elements)
-        full_mesh_rhs: (n_snap*n_rom,) numpy array
+        residual_snapshots: (n_var, n_dof, n_snap) numpy ndarray, where n_dof is the number of mesh degrees of freedom (DoFs) (nodes, volumes, or elements), n_var is the number of residual variables, and n_snap is the number of snapshots
+        test_basis: (n_snap, n_var, n_dof, n_mode) numpy ndarray, where n_snap is the number of test basis snapshots and n_mode is the number of modes in the basis.
+        n_var: int, the number of residual variables (e.g. for fluid flow, residual variable could be mass, x-momentum, y-momentum, z-momentum, and energy)
         tolerance: Double, the ECSW tolerance parameter. Lower values of tolerance will result in more mesh DoF samples
 
     Returns:
@@ -433,5 +435,28 @@ def ecsw_varying_test_basis(
         First array: (n_dof_sample_mesh,) numpy ndarray of ints, the mesh indices in the sample mesh.
         Second array: (n_dof_sample_mesh,) numpy ndarray of doubles, the corresponding sample mesh weights.
     """
+
+    (n_var, n_dof, n_snap) = residual_snapshots.shape
+    (n_snap_tb, n_var_tb, n_dof_tb, n_mode) = test_basis.shape
+    assert n_var == n_var_tb
+    assert n_dof == n_dof_tb
+    assert n_snap == n_snap_tb
+
+    # Construct sequence of fixed test basis matrices, then stack them
+    lhs_list = []
+    rhs_list = []
+    for i in range(n_snap):
+        # TODO need to incorporate residual scales here too, perhaps using scaler.py
+        test_basis_i = test_basis[i]
+        residual_snapshot_i = residual_snapshots[:,:,i]
+        residual_snapshot_i = residual_snapshot_i[:, :, np.newaxis]
+        full_mesh_lhs, full_mesh_rhs = _construct_linear_system(
+            residual_snapshot_i, test_basis_i, n_var
+        )
+        lhs_list.append(full_mesh_lhs)
+        rhs_list.append(full_mesh_rhs)
+
+    full_mesh_lhs = np.concatenate(lhs_list,axis=0)
+    full_mesh_rhs = np.concatenate(rhs_list,axis=0)
 
     return ecsw_solver(full_mesh_lhs, full_mesh_rhs, tolerance)

--- a/romtools/hyper_reduction/ecsw.py
+++ b/romtools/hyper_reduction/ecsw.py
@@ -437,7 +437,7 @@ def ecsw_varying_test_basis(
     """
 
     (n_var, n_dof, n_snap) = residual_snapshots.shape
-    (n_snap_tb, n_var_tb, n_dof_tb, n_mode) = test_basis.shape
+    (n_snap_tb, n_var_tb, n_dof_tb, _) = test_basis.shape
     assert n_var == n_var_tb
     assert n_dof == n_dof_tb
     assert n_snap == n_snap_tb
@@ -452,6 +452,48 @@ def ecsw_varying_test_basis(
         residual_snapshot_i = residual_snapshot_i[:, :, np.newaxis]
         full_mesh_lhs, full_mesh_rhs = _construct_linear_system(
             residual_snapshot_i, test_basis_i, n_var
+        )
+        lhs_list.append(full_mesh_lhs)
+        rhs_list.append(full_mesh_rhs)
+
+    full_mesh_lhs = np.concatenate(lhs_list,axis=0)
+    full_mesh_rhs = np.concatenate(rhs_list,axis=0)
+
+    return ecsw_solver(full_mesh_lhs, full_mesh_rhs, tolerance)
+
+
+def ecsw_lspg_zero_residual(
+    ecsw_solver: ECSWsolver,
+    test_basis: np.ndarray,
+    n_var: int,
+    tolerance: np.double,
+):
+    """
+    ECSW implementation for Least-Squares Petrov-Galerkin projection of a discrete system with near-zero residual snapshots
+    Uses the test basis as a snapshot instead, as proposed in section 3.2 of https://www.sciencedirect.com/science/article/pii/S0045782522004558.
+
+    Args:
+        ecsw_solver: ECSWsolver object corresponding to a child class with concrete implementations such as ECSWsolverNNLS.
+        test_basis: (n_snap, n_var, n_dof, n_mode) numpy ndarray, where n_snap is the number of test basis snapshots and n_mode is the number of modes in the basis.
+        n_var: int, the number of residual variables (e.g. for fluid flow, residual variable could be mass, x-momentum, y-momentum, z-momentum, and energy)
+        tolerance: Double, the ECSW tolerance parameter. Lower values of tolerance will result in more mesh DoF samples
+
+    Returns:
+        Tuple of numpy ndarrays.
+        First array: (n_dof_sample_mesh,) numpy ndarray of ints, the mesh indices in the sample mesh.
+        Second array: (n_dof_sample_mesh,) numpy ndarray of doubles, the corresponding sample mesh weights.
+    """
+
+    (n_snap, n_var, _, _) = test_basis.shape
+
+    # Construct sequence of fixed test basis matrices, then stack them
+    lhs_list = []
+    rhs_list = []
+    for i in range(n_snap):
+        # TODO need to incorporate residual scales here too, perhaps using scaler.py
+        test_basis_i = test_basis[i]
+        full_mesh_lhs, full_mesh_rhs = _construct_linear_system(
+            test_basis_i, test_basis_i, n_var
         )
         lhs_list.append(full_mesh_lhs)
         rhs_list.append(full_mesh_rhs)

--- a/tests/romtools/hyper_reduction/test_ecsw.py
+++ b/tests/romtools/hyper_reduction/test_ecsw.py
@@ -45,7 +45,7 @@ def test_ecsw_matrix():
 
 
 @pytest.mark.mpi_skip
-def test_full_ecsw():
+def test_full_ecsw_fixed_test_basis():
     # test ECSW
     n_var = 2
     nnls = ecsw.ECSWsolverNNLS()
@@ -78,10 +78,52 @@ def test_full_ecsw():
     assert np.allclose(sample_mesh_approx, approx)
 
 
+@pytest.mark.mpi_skip
+def test_full_ecsw_varying_test_basis():
+    # test ECSW
+    n_var = 2
+    n_dof = 10
+    n_snap = 5
+    n_mode = 3
+    nnls = ecsw.ECSWsolverNNLS()
+    residual_snapshots = np.random.normal(size=(n_dof*n_var, n_snap))
+    test_basis = np.zeros((n_snap,n_dof*n_var, n_mode))
+    for i in range(n_snap):
+        test_basis[i],_ = np.linalg.qr(np.random.normal(size=(n_dof*n_var, n_mode)))
+
+    # create corresponding tensors
+    residual_snapshots_tensor = _matrix_to_tensor(n_var,residual_snapshots)
+    test_basis_tensor = np.zeros((n_snap, n_var, n_dof, n_mode))
+    for i in range(n_snap):
+        test_basis_tensor[i] = _matrix_to_tensor(n_var,test_basis[i])
+
+    sample_mesh_indices, sample_mesh_weights = ecsw.ecsw_varying_test_basis(nnls, residual_snapshots_tensor, test_basis_tensor, n_var, 1e-4)
+    full_mesh_weights = np.zeros(residual_snapshots_tensor.shape[1])
+    full_mesh_weights[sample_mesh_indices] = sample_mesh_weights
+
+
+    sample_mesh_test_basis_tensor = test_basis_tensor[:,:,sample_mesh_indices, :]
+    sample_mesh_residual_snapshots_tensor = residual_snapshots_tensor[:,sample_mesh_indices, :]
+    sample_mesh_residual_snapshots = _tensor_to_matrix(sample_mesh_residual_snapshots_tensor)
+    
+    for i in range(n_snap):
+        # Check that the full approximation of the residual snapshots is correct
+        exact = (test_basis[i].T)@residual_snapshots[:,i]
+        approx = (test_basis[i].T)@(np.diag(full_mesh_weights.repeat(n_var))@residual_snapshots[:,i])
+
+        assert np.allclose(exact, approx)
+
+        # Check that the sample mesh indices are correct
+        sample_mesh_test_basis =  _tensor_to_matrix(sample_mesh_test_basis_tensor[i])
+        sample_mesh_residual_snapshot = sample_mesh_residual_snapshots[:,i]
+
+        sample_mesh_approx = (sample_mesh_test_basis.T)@(np.diag(sample_mesh_weights.repeat(n_var))@sample_mesh_residual_snapshot)
+
+        assert np.allclose(sample_mesh_approx, approx)
+
+
 if __name__ == "__main__":
-    test_full_ecsw()
+    test_full_ecsw_fixed_test_basis()
+    test_full_ecsw_varying_test_basis()
     test_ecsw_nnls()
     test_ecsw_matrix()
-
-    
-

--- a/tests/romtools/hyper_reduction/test_ecsw.py
+++ b/tests/romtools/hyper_reduction/test_ecsw.py
@@ -122,8 +122,48 @@ def test_full_ecsw_varying_test_basis():
         assert np.allclose(sample_mesh_approx, approx)
 
 
+@pytest.mark.mpi_skip
+def test_full_ecsw_lspg_zero_residual():
+    # test ECSW
+    n_var = 2
+    n_dof = 10
+    n_snap = 5
+    n_mode = 3
+    nnls = ecsw.ECSWsolverNNLS()
+    test_basis = np.zeros((n_snap,n_dof*n_var, n_mode))
+    for i in range(n_snap):
+        test_basis[i],_ = np.linalg.qr(np.random.normal(size=(n_dof*n_var, n_mode)))
+
+    # create corresponding tensors
+    test_basis_tensor = np.zeros((n_snap, n_var, n_dof, n_mode))
+    for i in range(n_snap):
+        test_basis_tensor[i] = _matrix_to_tensor(n_var,test_basis[i])
+
+    sample_mesh_indices, sample_mesh_weights = ecsw.ecsw_lspg_zero_residual(nnls, test_basis_tensor, n_var, 1e-4)
+    full_mesh_weights = np.zeros(test_basis_tensor.shape[2])
+    full_mesh_weights[sample_mesh_indices] = sample_mesh_weights
+
+
+    sample_mesh_test_basis_tensor = test_basis_tensor[:,:,sample_mesh_indices, :]
+    
+    for i in range(n_snap):
+        # Check that the full approximation of the residual snapshots is correct
+        exact = (test_basis[i].T)@test_basis[i]
+        approx = (test_basis[i].T)@(np.diag(full_mesh_weights.repeat(n_var))@test_basis[i])
+
+        assert np.allclose(exact, approx)
+
+        # Check that the sample mesh indices are correct
+        sample_mesh_test_basis =  _tensor_to_matrix(sample_mesh_test_basis_tensor[i])
+
+        sample_mesh_approx = (sample_mesh_test_basis.T)@(np.diag(sample_mesh_weights.repeat(n_var))@sample_mesh_test_basis)
+
+        assert np.allclose(sample_mesh_approx, approx)
+
+
 if __name__ == "__main__":
-    test_full_ecsw_fixed_test_basis()
-    test_full_ecsw_varying_test_basis()
     test_ecsw_nnls()
     test_ecsw_matrix()
+    test_full_ecsw_fixed_test_basis()
+    test_full_ecsw_varying_test_basis()
+    test_full_ecsw_lspg_zero_residual()


### PR DESCRIPTION
Updated ecsw_varying_test_basis to take in tensors containing snapshots of the test basis over time and the corresponding residual snapshots. 

Added a new method, ecsw_lspg_zero_residual which uses a tensor containing Jacobian-Basis product snapshots to compute ECSW weights and samples as proposed in section 3.2 of https://www.sciencedirect.com/science/article/pii/S0045782522004558.