### PR TITLE
Add standard greedy algorithm that uses an error estimate with no calibration

### DIFF
--- a/romtools/hyper_reduction/__init__.py
+++ b/romtools/hyper_reduction/__init__.py
@@ -48,8 +48,9 @@ The hyper-reduction library comprises a set of routines for hyper-reduction. Pre
 
 - The discrete empirical interpolation method (DEIM)
 - The energy conserving sample mesh and weighting method (ECSW)
+
 There are a number of approaches to sample mesh degrees of freedom and computed weight matrices for hyper-reduction approaches
-The hyper_reduction module provides these functionalities. Note that certain aspects of hyper-reduction are inherently problem-dependent.
+The `hyper_reduction` module provides these functionalities. Note that certain aspects of hyper-reduction are inherently problem-dependent.
 Implementations of these aspects, including the generation of residual snapshots and the construction of a sample mesh, are left to the user. 
 '''
 from romtools.hyper_reduction.ecsw import *

--- a/romtools/hyper_reduction/ecsw.py
+++ b/romtools/hyper_reduction/ecsw.py
@@ -44,7 +44,7 @@
 #
 
 """
-Implementation of Energy-conserving sampling and weighting (ECSW)hyper-reduction
+Implementation of Energy-conserving sampling and weighting (ECSW) hyper-reduction
 
 Energy-conserving sampling and weighting (ECSW) is a hyper-reduction approach
 originally developed specifically for solid mechanics problems, but it has

--- a/romtools/workflows/greedy/run_greedy.py
+++ b/romtools/workflows/greedy/run_greedy.py
@@ -59,7 +59,7 @@ The algorithm is as follows:
     \\; \\mathbf{u}_{\\mathrm{shift}} = \\mathbf{u}(\\mu_1)$$
  6. We then solve the resulting ROM for the remaining parameter samples $\\mathcal{D}_{\\mathrm{train}}$ to
     generate approximate solutions $\\mathbf{u}(\\mu), \\mu \\in \\mathcal{D}_{\\mathrm{train}}$
- 7. For each ROM solution $\\mathbf{u}(\\mu), \\mu \\in \\mathcal{D}_{\\mathrm{train}}$ we compuate an error
+ 7. For each ROM solution $\\mathbf{u}(\\mu), \\mu \\in \\mathcal{D}_{\\mathrm{train}}$ we compute an error
     estimate, $ e \\left(\\mu \\right) $
  8. If the maximum error estimate is less than some tolerance, we exit the algorithm. If not, we:
    - Set $ \\mu^* = \\underset{ \\mu \\in \\mathcal{D}_{\\mathrm{train}} }{ \\mathrm{arg\\; max} } \\; e
@@ -80,6 +80,8 @@ scaling based on $$C = \\frac{\\sum_{i=1}^j | e^q_j| }{ \\sum_{i=1}^j | e_j | }.
 The error at the $j+1$ iteration can be approximated by $C e(\\mu)$.
 This will adaptively scale the error estimate to match the QoI error as
 closely as possible, which can be helpful for defining exit criterion.
+
+Alternatively, if `calibrated_error` is set to `False`, then the scaling factor $C$ will always be $1$.
 '''
 
 import os
@@ -102,7 +104,8 @@ def run_greedy(fom_model: QoiModel,
                absolute_greedy_work_directory: str,
                tolerance: float,
                testing_sample_size: int = 10,
-               random_seed: int = 1):
+               random_seed: int = 1,
+               calibrated_error: bool=True):
     '''
     Main implementation of the greedy algorithm.
     '''
@@ -168,7 +171,7 @@ def run_greedy(fom_model: QoiModel,
 
     converged = False
     max_error_indicators = np.zeros(0)
-    reg = QoIvsErrorIndicatorRegressor()
+    reg = QoIvsErrorIndicatorRegressor(calibrated_error)
     qoi_errors = np.zeros(0)
     predicted_qoi_errors = np.zeros(0)
     greedy_file.flush()
@@ -291,22 +294,24 @@ class QoIvsErrorIndicatorRegressor:
     This class provides a simple linear regression model for estimating the
     scaling factor (c) between QoI error and the error indicator.
     '''
-    def __init__(self):
+    def __init__(self, calibrated_error: bool=True):
         '''
         Initializes the regressor with a default scaling factor of 1.0.
         '''
         self.__c = 1.
+        self.__calibrated_error = calibrated_error
 
     def fit(self, x, y):
         '''
-        Fits the regression model to the provided data points (x, y) to
-        estimate the scaling factor.
+        If calibrated_error was specified, this function fits the regression
+        model to the provided data points (x, y) to estimate the scaling factor.
 
         Args:
             x: Error indicator values.
             y: Corresponding QoI error values.
         '''
-        self.__c = np.mean(y) / np.mean(x)
+        if self.__calibrated_error:
+            self.__c = np.mean(y) / np.mean(x)
 
     def predict(self, x):
         '''

--- a/romtools/workflows/models.py
+++ b/romtools/workflows/models.py
@@ -21,7 +21,7 @@ class Model(Protocol):
         This function is called from the base directory and is
         responsible for populating the run directory located at run_directory.
 
-        Examples would be setuping up input files, linking mesh files.
+        Examples would be setting up input files, linking mesh files.
 
         Args:
           run_directory (str): Absolute path to run_directory.
@@ -33,7 +33,7 @@ class Model(Protocol):
     def run_model(self, run_directory: str, parameter_sample: dict) -> int:
         '''
         This function is called from the base directory. It needs to execute our
-        model.  If the model runs succesfully, return 0.  If fails, return 1.
+        model. If the model runs successfully, return 0. If fails, return 1.
 
         Args:
           run_directory (str): Absolute path to run_directory.

--- a/tests/romtools/workflows/greedy/test_greedy.py
+++ b/tests/romtools/workflows/greedy/test_greedy.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from romtools.workflows.models import *
 from romtools.workflows.model_builders import *
-from romtools.workflows.greedy.run_greedy import run_greedy
+from romtools.workflows.greedy.run_greedy import run_greedy, QoIvsErrorIndicatorRegressor
 from romtools.workflows.parameter_spaces import MonteCarloSampler, UniformParameterSpace
 
 
@@ -88,6 +88,23 @@ class MockQoiModelWithErrorEstimate:
 
 
 
+@pytest.mark.mpi_skip
+def test_greedy_error_regressor():
+    calibrated_reg = QoIvsErrorIndicatorRegressor(calibrated_error=True)
+    standard_reg = QoIvsErrorIndicatorRegressor(calibrated_error=False)
+
+    x = np.random.rand(5)
+    y = np.random.rand(5)
+
+    calibrated_reg.fit(x, y)
+    calibrated_prediction = calibrated_reg.predict(x)
+    exp_prediction = np.mean(y) / np.mean(x) * x
+
+    standard_reg.fit(x, y)
+    standard_prediction = standard_reg.predict(x)
+
+    assert np.allclose(calibrated_prediction, exp_prediction)
+    assert np.allclose(standard_prediction, x)
 
 @pytest.mark.mpi_skip
 def test_greedy(tmp_path):
@@ -108,8 +125,7 @@ def test_greedy(tmp_path):
                                             np.array([1, 2, 3]),
                                             sampler=MonteCarloSampler)
 
-
-    run_greedy(QoiModel,RomModelBuilder,my_parameter_space,wdir, 1e-5,5)
+    run_greedy(QoiModel,RomModelBuilder,my_parameter_space,wdir, 1e-5, 5)
 
     # First greedy pass
     foms_samples_run = [0, 1, 4, 2, 5]
@@ -169,3 +185,4 @@ def test_greedy(tmp_path):
 
 if __name__ == "__main__":
     test_greedy(os.getcwd() + '/greedy_test_tmp/')
+    test_greedy_error_regressor()


### PR DESCRIPTION
Adds optional `calibrated_error` argument to `run_greedy()` and tests for the `QoIvsErrorIndicatorRegressor` class.

Also makes small fixes to the documentation.