### PR TITLE
#272: Create all files/directories on remote host first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     'numpy',
     'scipy',
     'matplotlib',
+    'argparse',
+    'pyyaml',
 ]
 
 [tool.setuptools.dynamic]
@@ -24,10 +26,6 @@ where = ["."]
 [project.optional-dependencies]
 WithMPI = ['mpi4py>3.1.4']
 WithH5py = ['h5py']
-hpc = [
-    'argparse',
-    'pyyaml',
-]
 docs = [
     'docutils',
     'sphinx',

--- a/romtools/hpc/README.md
+++ b/romtools/hpc/README.md
@@ -7,26 +7,26 @@ from your local environment.
 
 ### Installation
 
-Install the hpc dependencies with
+Install the romtools dependencies with
 
 ```bash
-pip install .[hpc]
+pip install -e .
 ```
 
 in the project root.
 
 ## Running
 
-Run the basic workflow with:
+Run the example workflow with:
 
 ```sh
-python romtools/hpc/basic/workflow.py -r <remote-host> -u <username> -a <account/wcid>
+python romtools/hpc/example/workflow.py -r <remote-host> -u <username> -a <account/wcid>
 ```
 
 See all available arguments with:
 
 ```sh
-python romtools/hpc/basic/workflow.py -h
+python romtools/hpc/example/workflow.py -h
 ```
 
 ### Using a YAML Input File

--- a/romtools/hpc/decorators.py
+++ b/romtools/hpc/decorators.py
@@ -35,6 +35,6 @@ def require_connection(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         if self.conn is None:
-            raise RuntimeError("No connection established. Call __connect_to_remote() first.")
+            raise RuntimeError(f"No connection established. Call __connect_to_remote() before using {func.__name__}.")
         return func(self, *args, **kwargs)
     return wrapper

--- a/romtools/hpc/dispatcher.py
+++ b/romtools/hpc/dispatcher.py
@@ -1,8 +1,13 @@
+import io
 import os
 import re
 import time
 import shlex
+import tempfile
+import posixpath
 from typing import Optional
+
+import numpy as np
 
 from romtools.hpc.dispatcher_config import DispatcherConfig
 from romtools.hpc.logger import Logger
@@ -20,6 +25,7 @@ class Dispatcher:
     Arguments:
         logger: An instance of the Logger class for logging
         sampling_directory: An optional string for your local output directory
+        local_only: If True, do not attempt to establish an SSH connection or run any remote commands.
 
     The basic command is therefore:
         ssh user@remote -p port
@@ -27,7 +33,7 @@ class Dispatcher:
     Ensure that this command works without a password prompt (e.g., by setting up SSH keys)
     before using this tool.
     """
-    def __init__(self, logger: Logger, sampling_directory: str = "hpctools"):
+    def __init__(self, logger: Logger, sampling_directory: str = "hpctools", local_only: bool = False):
         # Core members
         self.logger = logger
         self.conn : Optional[Connection] = None
@@ -37,8 +43,14 @@ class Dispatcher:
         # Maintain list of current jobs
         self.current_jobs = []
 
-        # Initialization
-        self.__connect_to_remote()
+        # Establish connection (if desired)
+        if not local_only:
+            if self.config.remote and self.config.user:
+                self.__connect_to_remote()
+            else:
+                self.logger.log("Remote host or user not specified. Running in local-only mode.", local=True)
+
+        # Initialize directories
         self.__set_up_directories()
 
     # ------------------------------------------------------------------
@@ -46,9 +58,10 @@ class Dispatcher:
     # ------------------------------------------------------------------
 
     def __connect_to_remote(self) -> None:
-        assert self.config.remote is not None, "Remote host must be specified (use --remote argument on command line)."
-        assert self.config.user is not None, "Username must be specified (use --user argument on command line)."
-
+        """
+        Attempts to establish an SSH connection to the remote host using the provided configuration.
+        Exits if the connection fails.
+        """
         try:
             self.conn = Connection(host=self.config.remote, user=self.config.user, port=self.config.port)
             self.logger.set_hostname(self.conn.host)
@@ -64,19 +77,28 @@ class Dispatcher:
 
         # Then create the remote output directory
         if self.conn:
-            self.create_remote_directory(
+            self._create_remote_directory(
                 os.path.join(self.config.remote_root, self.sampling_directory),
                 base_dir=True
             )
 
     # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+
+    def _resolve_remote_path(self, remote_path: str, preserve_relative: bool = False) -> str:
+        if os.path.isabs(remote_path) or preserve_relative:
+            return remote_path
+        return os.path.join(self.config.remote_root, remote_path)
+
+    # ------------------------------------------------------------------
     # Resource management
     # ------------------------------------------------------------------
 
+    @require_connection
     def close(self):
-        if self.conn:
-            self.conn.close()
-            self.logger.log("Connection closed.", local=True)
+        self.conn.close()
+        self.logger.log("Connection closed.", local=True)
 
     def __enter__(self):
         return self
@@ -240,29 +262,11 @@ class Dispatcher:
         self.logger.debug(f"Cleaned up archives.")
 
     # ------------------------------------------------------------------
-    # Public API
+    # I/O methods
     # ------------------------------------------------------------------
 
-    def _resolve_remote_path(self, remote_path: str, preserve_relative: bool = False) -> str:
-        if os.path.isabs(remote_path) or preserve_relative:
-            return remote_path
-        return os.path.join(self.config.remote_root, remote_path)
-
     @require_connection
-    def cancel_job(self, job_id: str) -> str:
-        output = self.conn.run(f"scancel {job_id}")
-        self.logger.log(f"Cancelled SLURM job {job_id}.")
-        return output
-
-    @require_connection
-    def create_remote_directory(self, remote_dir: str, base_dir = False) -> None:
-        remote_dir = self._resolve_remote_path(remote_dir, preserve_relative=base_dir)
-
-        self.conn.run(f"mkdir -p {shlex.quote(remote_dir)}")
-        self.logger.log(f"Created remote directory: {remote_dir}")
-
-    @require_connection
-    def write_text(self, remote_path: str, content: str) -> None:
+    def _write_text(self, remote_path: str, content: str) -> None:
         """
         Write text content to a file on the remote host.
         """
@@ -273,6 +277,22 @@ class Dispatcher:
         if not res.ok:
             raise RuntimeError(f"Failed to write remote file {remote_path}: {res.stderr}")
         self.logger.log(f"Wrote remote file: {remote_path}")
+
+    @require_connection
+    def _create_remote_directory(self, remote_dir: str, base_dir = False) -> None:
+        remote_dir = self._resolve_remote_path(remote_dir, preserve_relative=base_dir)
+        self.conn.run(f"mkdir -p {shlex.quote(remote_dir)}")
+        self.logger.log(f"Created remote directory: {remote_dir}")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @require_connection
+    def cancel_job(self, job_id: str) -> str:
+        output = self.conn.run(f"scancel {job_id}")
+        self.logger.log(f"Cancelled SLURM job {job_id}.")
+        return output
 
     @require_connection
     def put(self, local_path: str, remote_path: str) -> None:
@@ -286,14 +306,47 @@ class Dispatcher:
         self.conn.get(remote_path, local_path)
         self.logger.log(f"Downloaded remote file {self.conn.host}:{remote_path} to local path {local_path}")
 
-    @require_connection
-    def path_exists(self, remote_path: str) -> bool:
-        remote_path = self._resolve_remote_path(remote_path)
-        result = self.conn.run(f"test -e {shlex.quote(remote_path)}")
-        return result.ok
+    def path_exists(self, path: str) -> bool:
+        if self.conn:
+            remote_path = self._resolve_remote_path(path)
+            result = self.conn.run(f"test -e {shlex.quote(remote_path)}")
+            return result.ok
+        return os.path.exists(path)
+
+    def create_empty_dir(self, dir_name: str):
+        if self.conn:
+            self._create_remote_directory(dir_name)
+        else:
+            os.makedirs(dir_name, exist_ok=True)
 
     @require_connection
     def dispatch(self, cmd: str, run_directory: str = None) -> str:
         job_id = self.__submit_slurm_job(cmd, run_directory)
         self.__wait_for_job(job_id)
         self.__collect_results()
+
+    def np_savetxt(self, path: str, arr: np.ndarray, fmt: str) -> None:
+        if self.conn:
+            buffer = io.StringIO()
+            np.savetxt(buffer, arr, fmt=fmt)
+            self._write_text(path, buffer.getvalue())
+        else:
+            np.savetxt(path, arr, fmt=fmt)
+        self.logger.log(f"Saved array to path {path}", local=(not self.conn))
+
+    def np_savez(self, path: str, **arrays) -> None:
+        """
+        Write multiple arrays to a .npz file.
+            - If a connection exists, the .npz file is first written to a local temp directory and then uploaded to the remote host.
+            - If no connection exists, the .npz file is written directly to the specified path.
+        """
+        if self.conn:
+            remote_dir = posixpath.dirname(path) or "."
+            assert self.path_exists(remote_dir)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                local_base = os.path.join(tmpdir, os.path.basename(path))
+                np.savez(local_base, **arrays)
+                self.put(local_base + ".npz", path + ".npz")
+        else:
+            np.savez(path, **arrays)
+        self.logger.log(f"Saved arrays to path {path}", local=(not self.conn))

--- a/romtools/hpc/dispatcher.py
+++ b/romtools/hpc/dispatcher.py
@@ -149,7 +149,7 @@ class Dispatcher:
             run_directory: The directory in which to execute the command on the remote host.
 
         Returns:
-            The SLURM job ID as a string.s
+            The SLURM job ID as a string
         """
         slurm_script_name = self.__generate_slurm_script(cmd, run_directory=run_directory)
         if run_directory:
@@ -243,6 +243,11 @@ class Dispatcher:
     # Public API
     # ------------------------------------------------------------------
 
+    def _resolve_remote_path(self, remote_path: str, preserve_relative: bool = False) -> str:
+        if os.path.isabs(remote_path) or preserve_relative:
+            return remote_path
+        return os.path.join(self.config.remote_root, remote_path)
+
     @require_connection
     def cancel_job(self, job_id: str) -> str:
         output = self.conn.run(f"scancel {job_id}")
@@ -251,12 +256,41 @@ class Dispatcher:
 
     @require_connection
     def create_remote_directory(self, remote_dir: str, base_dir = False) -> None:
-        # TODO: Need better method here
-        if not os.path.isabs(remote_dir) and not base_dir:
-            remote_dir = f"{shlex.quote(self.config.remote_root)}/{remote_dir}"
+        remote_dir = self._resolve_remote_path(remote_dir, preserve_relative=base_dir)
 
         self.conn.run(f"mkdir -p {shlex.quote(remote_dir)}")
         self.logger.log(f"Created remote directory: {remote_dir}")
+
+    @require_connection
+    def write_text(self, remote_path: str, content: str) -> None:
+        """
+        Write text content to a file on the remote host.
+        """
+        remote_path = self._resolve_remote_path(remote_path)
+        outer = "__HPCTOOLS_FILE_EOF__"
+        cmd = f"cat > {shlex.quote(remote_path)} << '{outer}'\n{content}\n{outer}\n"
+        res = self.conn.run(cmd)
+        if not res.ok:
+            raise RuntimeError(f"Failed to write remote file {remote_path}: {res.stderr}")
+        self.logger.log(f"Wrote remote file: {remote_path}")
+
+    @require_connection
+    def put(self, local_path: str, remote_path: str) -> None:
+        remote_path = self._resolve_remote_path(remote_path)
+        self.conn.put(local_path, remote_path)
+        self.logger.log(f"Uploaded local file {local_path} to {self.conn.host}:{remote_path}")
+
+    @require_connection
+    def get(self, remote_path: str, local_path: str) -> None:
+        remote_path = self._resolve_remote_path(remote_path)
+        self.conn.get(remote_path, local_path)
+        self.logger.log(f"Downloaded remote file {self.conn.host}:{remote_path} to local path {local_path}")
+
+    @require_connection
+    def path_exists(self, remote_path: str) -> bool:
+        remote_path = self._resolve_remote_path(remote_path)
+        result = self.conn.run(f"test -e {shlex.quote(remote_path)}")
+        return result.ok
 
     @require_connection
     def dispatch(self, cmd: str, run_directory: str = None) -> str:

--- a/romtools/hpc/dispatcher.py
+++ b/romtools/hpc/dispatcher.py
@@ -33,9 +33,9 @@ class Dispatcher:
     Ensure that this command works without a password prompt (e.g., by setting up SSH keys)
     before using this tool.
     """
-    def __init__(self, logger: Logger, sampling_directory: str = "hpctools", local_only: bool = False):
+    def __init__(self, logger: Logger = None, sampling_directory: str = "hpctools", local_only: bool = False):
         # Core members
-        self.logger = logger
+        self.logger = logger if logger is not None else Logger()
         self.conn : Optional[Connection] = None
         self.sampling_directory = os.path.basename(sampling_directory)
         self.config = DispatcherConfig(self.logger)
@@ -48,7 +48,7 @@ class Dispatcher:
             if self.config.remote and self.config.user:
                 self.__connect_to_remote()
             else:
-                self.logger.log("Remote host or user not specified. Running in local-only mode.", local=True)
+                self.logger.log("Remote host or user not specified (use -h for options). Running locally.", local=True)
 
         # Initialize directories
         self.__set_up_directories()
@@ -341,12 +341,25 @@ class Dispatcher:
             - If no connection exists, the .npz file is written directly to the specified path.
         """
         if self.conn:
-            remote_dir = posixpath.dirname(path) or "."
+            remote_path = posixpath.normpath(path)
+            if not remote_path.endswith(".npz"):
+                remote_path += ".npz"
+
+            remote_dir = posixpath.dirname(remote_path) or "."
             assert self.path_exists(remote_dir)
+
             with tempfile.TemporaryDirectory() as tmpdir:
-                local_base = os.path.join(tmpdir, os.path.basename(path))
-                np.savez(local_base, **arrays)
-                self.put(local_base + ".npz", path + ".npz")
+                local_path = os.path.join(tmpdir, posixpath.basename(remote_path))
+                np.savez(local_path, **arrays)
+                self.put(local_path, remote_path)
+
+            final_path = remote_path
         else:
-            np.savez(path, **arrays)
-        self.logger.log(f"Saved arrays to path {path}", local=(not self.conn))
+            local_path = os.path.normpath(path)
+            if not local_path.endswith(".npz"):
+                local_path += ".npz"
+
+            np.savez(local_path, **arrays)
+            final_path = local_path
+
+        self.logger.log(f"Saved arrays to path {final_path}", local=(not self.conn))

--- a/romtools/hpc/dispatcher.py
+++ b/romtools/hpc/dispatcher.py
@@ -205,7 +205,7 @@ class Dispatcher:
         Transfer the self.sampling_directory from remote to local.
         """
         remote_sampling_dir = f"{self.config.remote_root}/{self.sampling_directory}"
-        self.logger.log(f"Transfering results from {self.conn.host}:{remote_sampling_dir} -> {self.sampling_directory}", local=True)
+        self.logger.log(f"Transferring results from {self.conn.host}:{remote_sampling_dir} -> {self.sampling_directory}", local=True)
 
         # Pack all results into an archive
         archive_name = f"{self.config.job_name}.tar.gz"

--- a/romtools/hpc/dispatcher.py
+++ b/romtools/hpc/dispatcher.py
@@ -289,12 +289,6 @@ class Dispatcher:
     # ------------------------------------------------------------------
 
     @require_connection
-    def cancel_job(self, job_id: str) -> str:
-        output = self.conn.run(f"scancel {job_id}")
-        self.logger.log(f"Cancelled SLURM job {job_id}.")
-        return output
-
-    @require_connection
     def put(self, local_path: str, remote_path: str) -> None:
         remote_path = self._resolve_remote_path(remote_path)
         self.conn.put(local_path, remote_path)

--- a/romtools/hpc/dispatcher_config.py
+++ b/romtools/hpc/dispatcher_config.py
@@ -104,10 +104,7 @@ class DispatcherConfig:
         if not isinstance(data, dict):
             raise ValueError("YAML config must be a mapping/dictionary at the top level.")
 
-        # allow either nested or flat structure
-        section_map = { k: v.keys() for k, v in SCHEMA.items() }
-
-        # If any known section exists, treat as nested; otherwise treat as flat.
+        section_map = {k: v.keys() for k, v in SCHEMA.items()}
         is_nested = any(k in data for k in section_map.keys())
 
         def apply_kv(key: str, value):
@@ -150,10 +147,10 @@ class DispatcherConfig:
             for arg_name, arg in items.items():
                 new_group.add_argument(arg["cli"], f"--{arg_name}", type=arg["type"], help=arg["help"])
 
-        args = parser.parse_args()
+        args, _ = parser.parse_known_args()
         for name, value in vars(args).items():
             if name == "input":
-                continue  # already handled in __parse_yaml
+                continue
             if hasattr(self, name):
                 setattr(self, name, value)
             else:

--- a/romtools/hpc/example/ExampleModel.py
+++ b/romtools/hpc/example/ExampleModel.py
@@ -37,7 +37,4 @@ class ExampleModel:
         content = f"{socket.gethostname()}\n{int(time.time())}\n"
         with open(path, "w") as f:
             f.write(f"{content}\n")
-        return
-
-    def compute_qoi(self, run_directory: str, parameter_sample: dict) -> np.ndarray:
-        pass
+        return 0

--- a/romtools/hpc/example/ExampleModel.py
+++ b/romtools/hpc/example/ExampleModel.py
@@ -7,18 +7,15 @@ import numpy as np
 
 from romtools.hpc.dispatcher import Dispatcher
 
-class BasicModel:
+class ExampleModel:
 
     def __init__(self, dispatcher: Dispatcher = None) -> None:
         self.dispatcher = dispatcher
 
     def populate_run_directory(self, run_directory: str, parameter_sample: dict) -> None:
 
-        if self.dispatcher is not None:
-            self.dispatcher.create_remote_directory(run_directory)
-            return
-
-        os.makedirs(run_directory, exist_ok=True)
+        # Run directory is on remote host if dispatcher exists
+        pass
 
     def run_model(self, run_directory: str, parameter_sample: dict) -> int:
 
@@ -33,7 +30,7 @@ class BasicModel:
                 '
             """)
             self.dispatcher.dispatch(cmd, run_directory=run_directory)
-            return
+            return 0
 
         file_name = f"output-{socket.gethostname()}.txt"
         path = os.path.join(run_directory, file_name)

--- a/romtools/hpc/example/ExampleModel.py
+++ b/romtools/hpc/example/ExampleModel.py
@@ -3,8 +3,6 @@ import time
 import socket
 import textwrap
 
-import numpy as np
-
 from romtools.hpc.dispatcher import Dispatcher
 
 class ExampleModel:

--- a/romtools/hpc/example/ExampleModel.py
+++ b/romtools/hpc/example/ExampleModel.py
@@ -9,17 +9,14 @@ from romtools.hpc.dispatcher import Dispatcher
 
 class ExampleModel:
 
-    def __init__(self, dispatcher: Dispatcher = None) -> None:
-        self.dispatcher = dispatcher
-
-    def populate_run_directory(self, run_directory: str, parameter_sample: dict) -> None:
+    def populate_run_directory(self, run_directory: str, parameter_sample: dict, dispatcher: Dispatcher = None) -> None:
 
         # Run directory is on remote host if dispatcher exists
         pass
 
-    def run_model(self, run_directory: str, parameter_sample: dict) -> int:
+    def run_model(self, run_directory: str, parameter_sample: dict, dispatcher: Dispatcher = None) -> int:
 
-        if self.dispatcher is not None:
+        if dispatcher is not None:
             file_name = "output-$(hostname).txt"
             cmd = textwrap.dedent(f"""\
                 srun --ntasks=$SLURM_NNODES --ntasks-per-node=1 bash -c '
@@ -29,7 +26,7 @@ class ExampleModel:
                 EOF
                 '
             """)
-            self.dispatcher.dispatch(cmd, run_directory=run_directory)
+            dispatcher.dispatch(cmd, run_directory=run_directory)
             return 0
 
         file_name = f"output-{socket.gethostname()}.txt"

--- a/romtools/hpc/example/ExampleModelNoConn.py
+++ b/romtools/hpc/example/ExampleModelNoConn.py
@@ -1,0 +1,21 @@
+import os
+import time
+import socket
+
+from romtools.hpc.dispatcher import Dispatcher
+
+class ExampleModelNoConn:
+
+    def populate_run_directory(self, run_directory: str, parameter_sample: dict, dispatcher: Dispatcher = None) -> None:
+
+        # Run directory is on remote host if dispatcher exists
+        pass
+
+    def run_model(self, run_directory: str, parameter_sample: dict, dispatcher: Dispatcher = None) -> int:
+
+        file_name = f"output-{socket.gethostname()}.txt"
+        path = os.path.join(run_directory, file_name)
+        content = f"{socket.gethostname()}\n{int(time.time())}\n"
+        with open(path, "w") as f:
+            f.write(f"{content}\n")
+        return 0

--- a/romtools/hpc/example/ExampleModelNoConn.py
+++ b/romtools/hpc/example/ExampleModelNoConn.py
@@ -7,12 +7,9 @@ from romtools.hpc.dispatcher import Dispatcher
 class ExampleModelNoConn:
 
     def populate_run_directory(self, run_directory: str, parameter_sample: dict, dispatcher: Dispatcher = None) -> None:
-
-        # Run directory is on remote host if dispatcher exists
         pass
 
     def run_model(self, run_directory: str, parameter_sample: dict, dispatcher: Dispatcher = None) -> int:
-
         file_name = f"output-{socket.gethostname()}.txt"
         path = os.path.join(run_directory, file_name)
         content = f"{socket.gethostname()}\n{int(time.time())}\n"

--- a/romtools/hpc/example/ExampleParameterSpace.py
+++ b/romtools/hpc/example/ExampleParameterSpace.py
@@ -1,7 +1,7 @@
 import numpy as np
 import romtools.workflows.parameter_spaces
 
-class BasicParameterSpace(romtools.workflows.parameter_spaces.ParameterSpace):
+class ExampleParameterSpace(romtools.workflows.parameter_spaces.ParameterSpace):
     def __init__(self):
         self._names = ['x', 'y']
         self._mins = [0.0, 0.0]

--- a/romtools/hpc/example/workflow.py
+++ b/romtools/hpc/example/workflow.py
@@ -9,7 +9,7 @@ from romtools.hpc.example.ExampleParameterSpace import ExampleParameterSpace
 if __name__ == '__main__':
 
     # This will be created both locally and off of remote_root
-    output_dir_name = "testing_272"
+    output_dir_name = "sample_00"
 
     logger = Logger()
     with Dispatcher(
@@ -19,7 +19,7 @@ if __name__ == '__main__':
 
         model = ExampleModel(dispatcher)
         params = ExampleParameterSpace()
-        num_samples = 5
+        num_samples = 1
 
         romtools.workflows.run_sampling(
             model = model,

--- a/romtools/hpc/example/workflow.py
+++ b/romtools/hpc/example/workflow.py
@@ -3,13 +3,13 @@ import romtools.workflows
 from romtools.hpc.logger import Logger
 from romtools.hpc.dispatcher import Dispatcher
 
-from romtools.hpc.basic.BasicModel import BasicModel
-from romtools.hpc.basic.BasicParameterSpace import BasicParameterSpace
+from romtools.hpc.example.ExampleModel import ExampleModel
+from romtools.hpc.example.ExampleParameterSpace import ExampleParameterSpace
 
 if __name__ == '__main__':
 
     # This will be created both locally and off of remote_root
-    output_dir_name = "samples_01"
+    output_dir_name = "testing_272"
 
     logger = Logger()
     with Dispatcher(
@@ -17,17 +17,18 @@ if __name__ == '__main__':
         sampling_directory=output_dir_name,
     ) as dispatcher:
 
-        model = BasicModel(dispatcher)
-        params = BasicParameterSpace()
+        model = ExampleModel(dispatcher)
+        params = ExampleParameterSpace()
         num_samples = 5
 
         romtools.workflows.run_sampling(
             model = model,
             parameter_space = params,
             absolute_sampling_directory = output_dir_name,
-            evaluation_concurrency = 5,
+            evaluation_concurrency = 1,
             number_of_samples = num_samples,
             random_seed = 1,
             dry_run = False,
-            overwrite = True
+            overwrite = True,
+            dispatcher = dispatcher,
         )

--- a/romtools/hpc/example/workflow.py
+++ b/romtools/hpc/example/workflow.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
         sampling_directory=output_dir_name,
     ) as dispatcher:
 
-        model = ExampleModel(dispatcher)
+        model = ExampleModel()
         params = ExampleParameterSpace()
         num_samples = 1
 

--- a/romtools/hpc/example/workflow_noconn.py
+++ b/romtools/hpc/example/workflow_noconn.py
@@ -1,0 +1,27 @@
+import romtools.workflows
+
+from romtools.hpc.logger import Logger
+
+from romtools.hpc.example.ExampleModelNoConn import ExampleModelNoConn
+from romtools.hpc.example.ExampleParameterSpace import ExampleParameterSpace
+
+if __name__ == '__main__':
+
+    # This will be created both locally and off of remote_root
+    output_dir_name = "sample_00"
+
+    logger = Logger()
+    model = ExampleModelNoConn()
+    params = ExampleParameterSpace()
+    num_samples = 1
+
+    romtools.workflows.run_sampling(
+        model = model,
+        parameter_space = params,
+        absolute_sampling_directory = output_dir_name,
+        evaluation_concurrency = 1,
+        number_of_samples = num_samples,
+        random_seed = 1,
+        dry_run = False,
+        overwrite = True,
+    )

--- a/romtools/workflows/sampling/sampling.py
+++ b/romtools/workflows/sampling/sampling.py
@@ -139,7 +139,7 @@ def run_sampling(model: Model,
     np.random.seed(random_seed)
 
     # Create folder if it doesn't exist
-    create_empty_dir(absolute_sampling_directory, dispatcher=dispatcher)
+    create_empty_dir(absolute_sampling_directory, dispatcher)
 
     # create parameter samples
     parameter_samples = parameter_space.generate_samples(number_of_samples)
@@ -157,9 +157,9 @@ def run_sampling(model: Model,
     end_sample_index = starting_sample_index + parameter_samples.shape[0]
     for sample_index in range(starting_sample_index, end_sample_index):
         run_directory = f'{run_directory_base}{sample_index}'
-        create_empty_dir(run_directory, dispatcher=dispatcher)
+        create_empty_dir(run_directory, dispatcher)
         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index - starting_sample_index])
-        model.populate_run_directory(run_directory, parameter_dict)
+        model.populate_run_directory(run_directory, parameter_dict, dispatcher)
         run_directories.append(run_directory)
 
     # Print MPI warnings
@@ -188,7 +188,7 @@ def run_sampling(model: Model,
                 else:
                     print("Running")
                     parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
-                    sample_result = run_sample(run_directory, model, parameter_dict, compute_qoi=model_has_qoi, dispatcher=dispatcher)
+                    sample_result = run_sample(run_directory, model, parameter_dict, compute_qoi=model_has_qoi, dispatcher)
                     if model_has_qoi:
                         run_times[sample_index], qoi = sample_result
                         if qoi is not None:
@@ -261,7 +261,7 @@ def run_sampling(model: Model,
 def run_sample(run_directory: str, model: Model, parameter_sample: dict, compute_qoi: bool = False, dispatcher: Dispatcher = None):
     run_id = _get_run_id_from_run_dir(run_directory)
     ts = time.time()
-    flag = model.run_model(run_directory, parameter_sample)
+    flag = model.run_model(run_directory, parameter_sample, dispatcher)
     tf = time.time()
     run_time = tf - ts
     qoi = None

--- a/romtools/workflows/sampling/sampling.py
+++ b/romtools/workflows/sampling/sampling.py
@@ -89,29 +89,6 @@ def _compute_qoi_statistics(qoi_samples):
         "qoi_num_samples": np.array([qoi_array.shape[0]], dtype=int),
     }
 
-def _save_np_array(path: str, arr: np.ndarray, fmt: str, dispatcher: Dispatcher = None):
-    if dispatcher is not None:
-        buffer = io.StringIO()
-        np.savetxt(buffer, arr, fmt=fmt)
-        dispatcher.write_text(path, buffer.getvalue())
-    else:
-        np.savetxt(path, arr, fmt=fmt)
-
-def _save_npz(path_without_ext: str, dispatcher=None, **arrays):
-    if dispatcher is None:
-        np.savez(path_without_ext, **arrays)
-    else:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            local_base = os.path.join(tmpdir, os.path.basename(path_without_ext))
-            np.savez(local_base, **arrays)
-            dispatcher.put(local_base + ".npz", path_without_ext + ".npz")
-
-
-def _path_exists(path: str, dispatcher: Dispatcher = None) -> bool:
-    if dispatcher is not None:
-        return dispatcher.path_exists(path)
-    return os.path.exists(path)
-
 def run_sampling(model: Model,
                  parameter_space: ParameterSpace,
                  absolute_sampling_directory: str,
@@ -134,6 +111,9 @@ def run_sampling(model: Model,
     # and
     #   https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor
     #
+
+    if dispatcher is None:
+        dispatcher = Dispatcher()
     mp_cntxt=multiprocessing.get_context("spawn")
 
     np.random.seed(random_seed)
@@ -148,7 +128,7 @@ def run_sampling(model: Model,
     # Save parameter samples
     samples_file = os.path.join(absolute_sampling_directory, 'sample_parameters.txt')
     fmt = "%s "*parameter_space.get_dimensionality()
-    _save_np_array(samples_file, parameter_samples, fmt, dispatcher)
+    dispatcher.np_savetxt(samples_file, parameter_samples, fmt)
 
     # Set up model directories
     run_directory_base = f'{absolute_sampling_directory}/run_'
@@ -157,7 +137,7 @@ def run_sampling(model: Model,
     end_sample_index = starting_sample_index + parameter_samples.shape[0]
     for sample_index in range(starting_sample_index, end_sample_index):
         run_directory = f'{run_directory_base}{sample_index}'
-        create_empty_dir(run_directory, dispatcher)
+        dispatcher.create_empty_dir(run_directory)
         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index - starting_sample_index])
         model.populate_run_directory(run_directory, parameter_dict, dispatcher)
         run_directories.append(run_directory)
@@ -178,7 +158,7 @@ def run_sampling(model: Model,
                 print("=======  Sample " + str(sample_index) + " ============")
                 run_directory = f'{run_directory_base}{sample_index}'
                 passed_file = os.path.join(run_directory, 'passed.txt')
-                if _path_exists(passed_file, dispatcher) and not overwrite:
+                if dispatcher.path_exists(passed_file) and not overwrite:
                     print("Skipping (Sample has already run successfully)")
                     if model_has_qoi:
                         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
@@ -188,7 +168,7 @@ def run_sampling(model: Model,
                 else:
                     print("Running")
                     parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
-                    sample_result = run_sample(run_directory, model, parameter_dict, compute_qoi=model_has_qoi, dispatcher)
+                    sample_result = run_sample(run_directory, model, parameter_dict, compute_qoi=model_has_qoi, dispatcher=dispatcher)
                     if model_has_qoi:
                         run_times[sample_index], qoi = sample_result
                         if qoi is not None:
@@ -198,14 +178,14 @@ def run_sampling(model: Model,
                         run_times[sample_index] = sample_result
 
                     sample_stats_save_directory = f'{run_directory_base}{sample_index}/../'
-                    _save_npz(f'{sample_stats_save_directory}/sampling_stats', dispatcher, run_times=run_times)
+                    dispatcher.np_savez(f'{sample_stats_save_directory}/sampling_stats', run_times=run_times)
         else:
             #Identify samples to run
             samples_to_run = []
             for sample_index in range(0, number_of_samples):
                 run_directory = f'{run_directory_base}{sample_index}'
                 passed_file = os.path.join(run_directory, 'passed.txt')
-                if _path_exists(passed_file, dispatcher) and not overwrite:
+                if dispatcher.path_exists(passed_file) and not overwrite:
                     print(f"Skipping sample {sample_index} (Sample has already run successfully)")
                     if model_has_qoi:
                         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
@@ -242,12 +222,12 @@ def run_sampling(model: Model,
                 run_times.append(run_time)
 
             sample_stats_save_directory = f'{run_directory_base}{sample_index}/../'
-            _save_npz(f'{sample_stats_save_directory}/sampling_stats', dispatcher, run_times=run_times)
+            dispatcher.np_savez(f'{sample_stats_save_directory}/sampling_stats', run_times=run_times)
 
         if model_has_qoi and qoi_samples:
             qoi_stats = _compute_qoi_statistics(qoi_samples)
             sample_stats_save_directory = f'{run_directory_base}0/../'
-            _save_npz(f'{sample_stats_save_directory}/sampling_stats', dispatcher, run_times=run_times, **qoi_stats)
+            dispatcher.np_savez(f'{sample_stats_save_directory}/sampling_stats', run_times=run_times, **qoi_stats)
             print("QoI statistics:")
             print(f"  count: {qoi_stats['qoi_num_samples'][0]}")
             print(f"  mean: {qoi_stats['qoi_mean']}")
@@ -269,7 +249,7 @@ def run_sample(run_directory: str, model: Model, parameter_sample: dict, compute
     if flag == 0:
         print(f"Sample {run_id} is complete, run time = {run_time}")
         passed_file = os.path.join(run_directory, 'passed.txt')
-        _save_np_array(passed_file, np.array([0]), '%i', dispatcher)
+        dispatcher.np_savetxt(passed_file, np.array([0]), '%i')
         if compute_qoi:
             qoi = _compute_qoi_for_sample(model, run_directory, parameter_sample)
     else:

--- a/romtools/workflows/sampling/sampling.py
+++ b/romtools/workflows/sampling/sampling.py
@@ -119,7 +119,7 @@ def run_sampling(model: Model,
     np.random.seed(random_seed)
 
     # Create folder if it doesn't exist
-    create_empty_dir(absolute_sampling_directory, dispatcher)
+    dispatcher.create_empty_dir(absolute_sampling_directory)
 
     # create parameter samples
     parameter_samples = parameter_space.generate_samples(number_of_samples)

--- a/romtools/workflows/sampling/sampling.py
+++ b/romtools/workflows/sampling/sampling.py
@@ -43,12 +43,15 @@
 # ************************************************************************
 #
 
+import io
 import os
 import time
+import tempfile
 import numpy as np
 import concurrent.futures
 import multiprocessing
 
+from romtools.hpc.dispatcher import Dispatcher
 from romtools.workflows.workflow_utils import create_empty_dir
 from romtools.workflows.models import Model
 from romtools.workflows.parameter_spaces import ParameterSpace
@@ -86,6 +89,28 @@ def _compute_qoi_statistics(qoi_samples):
         "qoi_num_samples": np.array([qoi_array.shape[0]], dtype=int),
     }
 
+def _save_np_array(path: str, arr: np.ndarray, fmt: str, dispatcher: Dispatcher = None):
+    if dispatcher is not None:
+        buffer = io.StringIO()
+        np.savetxt(buffer, arr, fmt=fmt)
+        dispatcher.write_text(path, buffer.getvalue())
+    else:
+        np.savetxt(path, arr, fmt=fmt)
+
+def _save_npz(path_without_ext: str, dispatcher=None, **arrays):
+    if dispatcher is None:
+        np.savez(path_without_ext, **arrays)
+    else:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_base = os.path.join(tmpdir, os.path.basename(path_without_ext))
+            np.savez(local_base, **arrays)
+            dispatcher.put(local_base + ".npz", path_without_ext + ".npz")
+
+
+def _path_exists(path: str, dispatcher: Dispatcher = None) -> bool:
+    if dispatcher is not None:
+        return dispatcher.path_exists(path)
+    return os.path.exists(path)
 
 def run_sampling(model: Model,
                  parameter_space: ParameterSpace,
@@ -94,7 +119,8 @@ def run_sampling(model: Model,
                  number_of_samples: int = 10,
                  random_seed: int = 1,
                  dry_run: bool = False,
-                 overwrite: bool = False):
+                 overwrite: bool = False,
+                 dispatcher: Dispatcher = None):
     '''
     Core algorithm
     '''
@@ -113,14 +139,16 @@ def run_sampling(model: Model,
     np.random.seed(random_seed)
 
     # Create folder if it doesn't exist
-    create_empty_dir(absolute_sampling_directory)
+    create_empty_dir(absolute_sampling_directory, dispatcher=dispatcher)
 
     # create parameter samples
     parameter_samples = parameter_space.generate_samples(number_of_samples)
     parameter_names = parameter_space.get_names()
 
     # Save parameter samples
-    np.savetxt(f'{absolute_sampling_directory}/sample_parameters.txt', parameter_samples, fmt="%s "*parameter_space.get_dimensionality())
+    samples_file = os.path.join(absolute_sampling_directory, 'sample_parameters.txt')
+    fmt = "%s "*parameter_space.get_dimensionality()
+    _save_np_array(samples_file, parameter_samples, fmt, dispatcher)
 
     # Set up model directories
     run_directory_base = f'{absolute_sampling_directory}/run_'
@@ -129,7 +157,7 @@ def run_sampling(model: Model,
     end_sample_index = starting_sample_index + parameter_samples.shape[0]
     for sample_index in range(starting_sample_index, end_sample_index):
         run_directory = f'{run_directory_base}{sample_index}'
-        create_empty_dir(run_directory)
+        create_empty_dir(run_directory, dispatcher=dispatcher)
         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index - starting_sample_index])
         model.populate_run_directory(run_directory, parameter_dict)
         run_directories.append(run_directory)
@@ -149,7 +177,8 @@ def run_sampling(model: Model,
             for sample_index in range(0, number_of_samples):
                 print("=======  Sample " + str(sample_index) + " ============")
                 run_directory = f'{run_directory_base}{sample_index}'
-                if "passed.txt" in os.listdir(run_directory) and not overwrite:
+                passed_file = os.path.join(run_directory, 'passed.txt')
+                if _path_exists(passed_file, dispatcher) and not overwrite:
                     print("Skipping (Sample has already run successfully)")
                     if model_has_qoi:
                         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
@@ -159,7 +188,7 @@ def run_sampling(model: Model,
                 else:
                     print("Running")
                     parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
-                    sample_result = run_sample(run_directory, model, parameter_dict, compute_qoi=model_has_qoi)
+                    sample_result = run_sample(run_directory, model, parameter_dict, compute_qoi=model_has_qoi, dispatcher=dispatcher)
                     if model_has_qoi:
                         run_times[sample_index], qoi = sample_result
                         if qoi is not None:
@@ -167,15 +196,16 @@ def run_sampling(model: Model,
                             qoi_samples.append(qoi)
                     else:
                         run_times[sample_index] = sample_result
+
                     sample_stats_save_directory = f'{run_directory_base}{sample_index}/../'
-                    np.savez(f'{sample_stats_save_directory}/sampling_stats',
-                             run_times=run_times)
+                    _save_npz(f'{sample_stats_save_directory}/sampling_stats', dispatcher, run_times=run_times)
         else:
             #Identify samples to run
             samples_to_run = []
             for sample_index in range(0, number_of_samples):
                 run_directory = f'{run_directory_base}{sample_index}'
-                if "passed.txt" in os.listdir(run_directory) and not overwrite:
+                passed_file = os.path.join(run_directory, 'passed.txt')
+                if _path_exists(passed_file, dispatcher) and not overwrite:
                     print(f"Skipping sample {sample_index} (Sample has already run successfully)")
                     if model_has_qoi:
                         parameter_dict = _create_parameter_dict(parameter_names, parameter_samples[sample_index])
@@ -192,6 +222,7 @@ def run_sampling(model: Model,
                         model,
                         _create_parameter_dict(parameter_names, parameter_samples[sample_id]),
                         model_has_qoi,
+                        dispatcher,
                     ): sample_id for sample_id in samples_to_run
                 }
 
@@ -209,13 +240,14 @@ def run_sampling(model: Model,
                 else:
                     run_time = sample_result
                 run_times.append(run_time)
+
             sample_stats_save_directory = f'{run_directory_base}{sample_index}/../'
-            np.savez(f'{sample_stats_save_directory}/sampling_stats', run_times=run_times)
+            _save_npz(f'{sample_stats_save_directory}/sampling_stats', dispatcher, run_times=run_times)
 
         if model_has_qoi and qoi_samples:
             qoi_stats = _compute_qoi_statistics(qoi_samples)
             sample_stats_save_directory = f'{run_directory_base}0/../'
-            np.savez(f'{sample_stats_save_directory}/sampling_stats', run_times=run_times, **qoi_stats)
+            _save_npz(f'{sample_stats_save_directory}/sampling_stats', dispatcher, run_times=run_times, **qoi_stats)
             print("QoI statistics:")
             print(f"  count: {qoi_stats['qoi_num_samples'][0]}")
             print(f"  mean: {qoi_stats['qoi_mean']}")
@@ -226,7 +258,7 @@ def run_sampling(model: Model,
     return run_directories
 
 
-def run_sample(run_directory: str, model: Model, parameter_sample: dict, compute_qoi: bool = False):
+def run_sample(run_directory: str, model: Model, parameter_sample: dict, compute_qoi: bool = False, dispatcher: Dispatcher = None):
     run_id = _get_run_id_from_run_dir(run_directory)
     ts = time.time()
     flag = model.run_model(run_directory, parameter_sample)
@@ -236,7 +268,8 @@ def run_sample(run_directory: str, model: Model, parameter_sample: dict, compute
 
     if flag == 0:
         print(f"Sample {run_id} is complete, run time = {run_time}")
-        np.savetxt(os.path.join(run_directory, 'passed.txt'), np.array([0]), '%i')
+        passed_file = os.path.join(run_directory, 'passed.txt')
+        _save_np_array(passed_file, np.array([0]), '%i', dispatcher)
         if compute_qoi:
             qoi = _compute_qoi_for_sample(model, run_directory, parameter_sample)
     else:

--- a/romtools/workflows/workflow_utils.py
+++ b/romtools/workflows/workflow_utils.py
@@ -9,13 +9,7 @@ from romtools.hpc.dispatcher import Dispatcher
 def create_empty_dir(dir_name: str, dispatcher: Dispatcher = None):
     '''
     Create empty directory
-
-    If dispatcher is provided, the directory is created on the remote host.
     '''
-    if dispatcher is not None:
-        dispatcher.create_remote_directory(dir_name)
-        return
-
     if os.path.exists(dir_name):
         pass
     else:

--- a/romtools/workflows/workflow_utils.py
+++ b/romtools/workflows/workflow_utils.py
@@ -3,11 +3,19 @@ import os
 import shutil
 import subprocess
 
+from romtools.hpc.dispatcher import Dispatcher
 
-def create_empty_dir(dir_name: str):
+
+def create_empty_dir(dir_name: str, dispatcher: Dispatcher = None):
     '''
     Create empty directory
+
+    If dispatcher is provided, the directory is created on the remote host.
     '''
+    if dispatcher is not None:
+        dispatcher.create_remote_directory(dir_name)
+        return
+
     if os.path.exists(dir_name):
         pass
     else:

--- a/romtools/workflows/workflow_utils.py
+++ b/romtools/workflows/workflow_utils.py
@@ -3,10 +3,8 @@ import os
 import shutil
 import subprocess
 
-from romtools.hpc.dispatcher import Dispatcher
 
-
-def create_empty_dir(dir_name: str, dispatcher: Dispatcher = None):
+def create_empty_dir(dir_name: str):
     '''
     Create empty directory
     '''

--- a/tests/romtools/workflows/sampling/test_sampling.py
+++ b/tests/romtools/workflows/sampling/test_sampling.py
@@ -2,14 +2,9 @@ import pytest
 import os
 import numpy as np
 import time
-import shutil
-
-from types import SimpleNamespace
 
 from romtools.workflows.sampling.sampling import run_sampling
 from romtools.workflows.parameter_spaces import MonteCarloSampler, UniformParameterSpace, ConstParameterSpace
-from romtools.hpc.connection import Result
-from romtools.hpc.dispatcher import Dispatcher
 
 def _get_run_id(run_dir):
     return int(run_dir.split('_')[-1])
@@ -52,66 +47,6 @@ class MockQoiModel:
     def compute_qoi(self, run_dir, parameter_sample):
         parameter_values = np.load(f'{run_dir}/parameter_values.npz')['parameter_values']
         return np.array([np.sum(parameter_values)])
-
-
-class RemoteMockDispatcher:
-    def __init__(self, remote_root):
-        self.remote_root = str(remote_root)
-
-    def _resolve_remote_path(self, remote_path):
-        if os.path.isabs(remote_path):
-            return remote_path
-        return os.path.join(self.remote_root, remote_path)
-
-    def create_remote_directory(self, remote_dir):
-        os.makedirs(self._resolve_remote_path(remote_dir), exist_ok=True)
-
-    def write_text(self, remote_path, content):
-        resolved_path = self._resolve_remote_path(remote_path)
-        os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
-        with open(resolved_path, 'w', encoding='utf-8') as output_file:
-            output_file.write(content)
-
-    def put(self, local_path, remote_path):
-        resolved_path = self._resolve_remote_path(remote_path)
-        os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
-        shutil.copy(local_path, resolved_path)
-
-    def path_exists(self, remote_path):
-        return os.path.exists(self._resolve_remote_path(remote_path))
-
-
-class RemoteMockModel:
-    def __init__(self, dispatcher):
-        self.dispatcher = dispatcher
-
-    def populate_run_directory(self, run_dir, parameter_sample):
-        self.dispatcher.write_text(
-            f'{run_dir}/parameter_values.txt',
-            ' '.join(str(value) for value in parameter_sample.values()),
-        )
-
-    def run_model(self, run_dir, parameter_sample):
-        self.dispatcher.write_text(f'{run_dir}/passed.txt', '0\n')
-        return 0
-
-
-class RecordingConnection:
-    def __init__(self):
-        self.host = 'remote-host'
-        self.commands = []
-        self.put_calls = []
-        self.get_calls = []
-
-    def run(self, command):
-        self.commands.append(command)
-        return Result('', '', 0)
-
-    def put(self, local_path, remote_path):
-        self.put_calls.append((local_path, remote_path))
-
-    def get(self, remote_path, local_path):
-        self.get_calls.append((remote_path, local_path))
 
 
 def run_sampler(tmp_path, dry_run=False, overwrite=True):
@@ -210,68 +145,6 @@ def test_sampler_qoi_stats(tmp_path):
     np.testing.assert_allclose(stats["qoi_min"], np.array([3.0]))
     np.testing.assert_allclose(stats["qoi_max"], np.array([3.0]))
     np.testing.assert_array_equal(stats["qoi_num_samples"], np.array([4]))
-
-
-@pytest.mark.mpi_skip
-def test_sampler_dispatcher_uses_remote_filesystem(tmp_path):
-    remote_root = tmp_path / 'remote-root'
-    dispatcher = RemoteMockDispatcher(remote_root)
-    parameter_space = ConstParameterSpace(['u', 'v'], [1.0, 2.0])
-    model = RemoteMockModel(dispatcher)
-
-    run_sampling(
-        model,
-        parameter_space,
-        absolute_sampling_directory='samples_01',
-        evaluation_concurrency=1,
-        number_of_samples=2,
-        dry_run=False,
-        overwrite=False,
-        dispatcher=dispatcher,
-    )
-    first_timestamp = os.stat(remote_root / 'samples_01' / 'run_0' / 'passed.txt').st_mtime
-
-    run_sampling(
-        model,
-        parameter_space,
-        absolute_sampling_directory='samples_01',
-        evaluation_concurrency=1,
-        number_of_samples=2,
-        dry_run=False,
-        overwrite=False,
-        dispatcher=dispatcher,
-    )
-
-    assert os.path.exists(remote_root / 'samples_01' / 'sample_parameters.txt')
-    assert os.path.exists(remote_root / 'samples_01' / 'sampling_stats.npz')
-    assert os.path.exists(remote_root / 'samples_01' / 'run_0' / 'parameter_values.txt')
-    assert os.stat(remote_root / 'samples_01' / 'run_0' / 'passed.txt').st_mtime == first_timestamp
-
-
-def test_dispatcher_resolves_relative_remote_paths(tmp_path):
-    dispatcher = object.__new__(Dispatcher)
-    dispatcher.logger = SimpleNamespace(log=lambda *args, **kwargs: None)
-    dispatcher.conn = RecordingConnection()
-    dispatcher.config = SimpleNamespace(remote_root='/remote/root')
-
-    dispatcher.create_remote_directory('samples_01/run_0')
-    dispatcher.write_text('samples_01/output.txt', 'value\n')
-
-    local_file = tmp_path / 'stats.npz'
-    local_file.write_bytes(b'npz')
-    dispatcher.put(str(local_file), 'samples_01/sampling_stats.npz')
-    dispatcher.get('samples_01/sampling_stats.npz', str(tmp_path / 'downloaded.npz'))
-    assert dispatcher.path_exists('samples_01/output.txt')
-
-    assert dispatcher.conn.commands[0] == 'mkdir -p /remote/root/samples_01/run_0'
-    assert dispatcher.conn.commands[1].startswith("cat > /remote/root/samples_01/output.txt << '")
-    assert dispatcher.conn.put_calls == [
-        (str(local_file), '/remote/root/samples_01/sampling_stats.npz')
-    ]
-    assert dispatcher.conn.get_calls == [
-        ('/remote/root/samples_01/sampling_stats.npz', str(tmp_path / 'downloaded.npz'))
-    ]
-    assert dispatcher.conn.commands[2] == 'test -e /remote/root/samples_01/output.txt'
 
 if __name__ == "__main__":
     test_sampler()

--- a/tests/romtools/workflows/sampling/test_sampling.py
+++ b/tests/romtools/workflows/sampling/test_sampling.py
@@ -2,9 +2,14 @@ import pytest
 import os
 import numpy as np
 import time
+import shutil
+
+from types import SimpleNamespace
 
 from romtools.workflows.sampling.sampling import run_sampling
 from romtools.workflows.parameter_spaces import MonteCarloSampler, UniformParameterSpace, ConstParameterSpace
+from romtools.hpc.connection import Result
+from romtools.hpc.dispatcher import Dispatcher
 
 def _get_run_id(run_dir):
     return int(run_dir.split('_')[-1])
@@ -47,6 +52,66 @@ class MockQoiModel:
     def compute_qoi(self, run_dir, parameter_sample):
         parameter_values = np.load(f'{run_dir}/parameter_values.npz')['parameter_values']
         return np.array([np.sum(parameter_values)])
+
+
+class RemoteMockDispatcher:
+    def __init__(self, remote_root):
+        self.remote_root = str(remote_root)
+
+    def _resolve_remote_path(self, remote_path):
+        if os.path.isabs(remote_path):
+            return remote_path
+        return os.path.join(self.remote_root, remote_path)
+
+    def create_remote_directory(self, remote_dir):
+        os.makedirs(self._resolve_remote_path(remote_dir), exist_ok=True)
+
+    def write_text(self, remote_path, content):
+        resolved_path = self._resolve_remote_path(remote_path)
+        os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
+        with open(resolved_path, 'w', encoding='utf-8') as output_file:
+            output_file.write(content)
+
+    def put(self, local_path, remote_path):
+        resolved_path = self._resolve_remote_path(remote_path)
+        os.makedirs(os.path.dirname(resolved_path), exist_ok=True)
+        shutil.copy(local_path, resolved_path)
+
+    def path_exists(self, remote_path):
+        return os.path.exists(self._resolve_remote_path(remote_path))
+
+
+class RemoteMockModel:
+    def __init__(self, dispatcher):
+        self.dispatcher = dispatcher
+
+    def populate_run_directory(self, run_dir, parameter_sample):
+        self.dispatcher.write_text(
+            f'{run_dir}/parameter_values.txt',
+            ' '.join(str(value) for value in parameter_sample.values()),
+        )
+
+    def run_model(self, run_dir, parameter_sample):
+        self.dispatcher.write_text(f'{run_dir}/passed.txt', '0\n')
+        return 0
+
+
+class RecordingConnection:
+    def __init__(self):
+        self.host = 'remote-host'
+        self.commands = []
+        self.put_calls = []
+        self.get_calls = []
+
+    def run(self, command):
+        self.commands.append(command)
+        return Result('', '', 0)
+
+    def put(self, local_path, remote_path):
+        self.put_calls.append((local_path, remote_path))
+
+    def get(self, remote_path, local_path):
+        self.get_calls.append((remote_path, local_path))
 
 
 def run_sampler(tmp_path, dry_run=False, overwrite=True):
@@ -145,6 +210,68 @@ def test_sampler_qoi_stats(tmp_path):
     np.testing.assert_allclose(stats["qoi_min"], np.array([3.0]))
     np.testing.assert_allclose(stats["qoi_max"], np.array([3.0]))
     np.testing.assert_array_equal(stats["qoi_num_samples"], np.array([4]))
+
+
+@pytest.mark.mpi_skip
+def test_sampler_dispatcher_uses_remote_filesystem(tmp_path):
+    remote_root = tmp_path / 'remote-root'
+    dispatcher = RemoteMockDispatcher(remote_root)
+    parameter_space = ConstParameterSpace(['u', 'v'], [1.0, 2.0])
+    model = RemoteMockModel(dispatcher)
+
+    run_sampling(
+        model,
+        parameter_space,
+        absolute_sampling_directory='samples_01',
+        evaluation_concurrency=1,
+        number_of_samples=2,
+        dry_run=False,
+        overwrite=False,
+        dispatcher=dispatcher,
+    )
+    first_timestamp = os.stat(remote_root / 'samples_01' / 'run_0' / 'passed.txt').st_mtime
+
+    run_sampling(
+        model,
+        parameter_space,
+        absolute_sampling_directory='samples_01',
+        evaluation_concurrency=1,
+        number_of_samples=2,
+        dry_run=False,
+        overwrite=False,
+        dispatcher=dispatcher,
+    )
+
+    assert os.path.exists(remote_root / 'samples_01' / 'sample_parameters.txt')
+    assert os.path.exists(remote_root / 'samples_01' / 'sampling_stats.npz')
+    assert os.path.exists(remote_root / 'samples_01' / 'run_0' / 'parameter_values.txt')
+    assert os.stat(remote_root / 'samples_01' / 'run_0' / 'passed.txt').st_mtime == first_timestamp
+
+
+def test_dispatcher_resolves_relative_remote_paths(tmp_path):
+    dispatcher = object.__new__(Dispatcher)
+    dispatcher.logger = SimpleNamespace(log=lambda *args, **kwargs: None)
+    dispatcher.conn = RecordingConnection()
+    dispatcher.config = SimpleNamespace(remote_root='/remote/root')
+
+    dispatcher.create_remote_directory('samples_01/run_0')
+    dispatcher.write_text('samples_01/output.txt', 'value\n')
+
+    local_file = tmp_path / 'stats.npz'
+    local_file.write_bytes(b'npz')
+    dispatcher.put(str(local_file), 'samples_01/sampling_stats.npz')
+    dispatcher.get('samples_01/sampling_stats.npz', str(tmp_path / 'downloaded.npz'))
+    assert dispatcher.path_exists('samples_01/output.txt')
+
+    assert dispatcher.conn.commands[0] == 'mkdir -p /remote/root/samples_01/run_0'
+    assert dispatcher.conn.commands[1].startswith("cat > /remote/root/samples_01/output.txt << '")
+    assert dispatcher.conn.put_calls == [
+        (str(local_file), '/remote/root/samples_01/sampling_stats.npz')
+    ]
+    assert dispatcher.conn.get_calls == [
+        ('/remote/root/samples_01/sampling_stats.npz', str(tmp_path / 'downloaded.npz'))
+    ]
+    assert dispatcher.conn.commands[2] == 'test -e /remote/root/samples_01/output.txt'
 
 if __name__ == "__main__":
     test_sampler()

--- a/tests/romtools/workflows/sampling/test_sampling.py
+++ b/tests/romtools/workflows/sampling/test_sampling.py
@@ -13,13 +13,13 @@ class MockModel:
     def __init__(self):
         pass
 
-    def populate_run_directory(self, run_dir, parameter_sample):
+    def populate_run_directory(self, run_dir, parameter_sample, dispatcher=None):
         parameter_values = np.zeros(0)
         for parameter_name in list(parameter_sample.keys()):
             parameter_values = np.append(parameter_values, parameter_sample[parameter_name])
         np.savez(f'{run_dir}/parameter_values.npz', parameter_values=parameter_values)
 
-    def run_model(self, run_dir, parameter_sample):
+    def run_model(self, run_dir, parameter_sample, dispatcher=None):
         print("running model in ", run_dir)
         params_input = np.load(f'{run_dir}/parameter_values.npz')['parameter_values']
         for i in range(0, len(parameter_sample)):
@@ -36,15 +36,15 @@ class MockModel:
 
 
 class MockQoiModel:
-    def populate_run_directory(self, run_dir, parameter_sample):
+    def populate_run_directory(self, run_dir, parameter_sample, dispatcher=None):
         parameter_values = np.asarray(list(parameter_sample.values()), dtype=float)
         np.savez(f'{run_dir}/parameter_values.npz', parameter_values=parameter_values)
 
-    def run_model(self, run_dir, parameter_sample):
+    def run_model(self, run_dir, parameter_sample, dispatcher=None):
         np.savetxt(f'{run_dir}/passed.txt', np.array([0]), '%i')
         return 0
 
-    def compute_qoi(self, run_dir, parameter_sample):
+    def compute_qoi(self, run_dir, parameter_sample, dispatcher=None):
         parameter_values = np.load(f'{run_dir}/parameter_values.npz')['parameter_values']
         return np.array([np.sum(parameter_values)])
 


### PR DESCRIPTION
Fixes #272 

## Design Choices

1. The Dispatcher is created at the workflow level and passed to the `run_sampling()` function
    - This in turn passes the Dispatcher through to the model for the run/populate methods
2. There is now a default Dispatcher (for when no host/user is specified) that wraps all the basic commands but just executes them locally.
    - So now the workflow methods (e.g. `run_sampling()`) can just use `dispatcher.np_savetxt` for example, and this will execute on the remote host if dispatcher has a connection (`self.conn is not None`) or locally if no dispatcher was configured (same as `np.savetxt`)


I also renamed `BasicModel` -> `ExampleModel` to be more clear about what it is

## No Connection Model

I've added a `ExampleModelNoConn` and a corresponding `workflow_noconn.py` to test the route with the default dispatcher. Just run:

```sh
python example/workflow_noconn.py
```

No need to specify any CLI args

## Possible Issues

The current implementation requires any model passed to the `run_sampling()` workflow to have methods that can take a `dispatcher`--even if it's just the default dispatcher that doesn't do anything.
