### PR TITLE
#292: Initial scaffolding to return job status from sacct

### DIFF
--- a/romtools/hpc/configuration.py
+++ b/romtools/hpc/configuration.py
@@ -26,7 +26,7 @@ SCHEMA = {
         "partition":      {"cli": "-q", "type": str, "help": "The partition to submit the SLURM job to (e.g., batch, short)."},
         "poll_interval":  {"cli": "-P", "type": int, "help": "Seconds between squeue polls when waiting for job completion (default: 30)."},
         "account":        {"cli": "-a", "type": str, "help": "The account WCID to charge for the SLURM job."},
-        "accounting_timeout": {"cli": "-at", "type": str, "help": "Time until giving up retrieving job's sacct exit code."},
+        "timeout":        {"cli": "-T", "type": str, "help": "Time until giving up retrieving job's sacct exit code."},
     },
     "output": {
         "debug": {"cli": "-d", "type": bool, "help": "Whether to enable debug logging."},
@@ -129,7 +129,7 @@ class Configuration:
         self.partition = "short"
         self.account = None
         self.poll_interval = 30
-        self.accounting_timeout = 240
+        self.timeout = 240
 
         # Workflow configuration
         self.remote_root = "hpctools_campaigns"

--- a/romtools/hpc/configuration.py
+++ b/romtools/hpc/configuration.py
@@ -26,6 +26,7 @@ SCHEMA = {
         "partition":      {"cli": "-q", "type": str, "help": "The partition to submit the SLURM job to (e.g., batch, short)."},
         "poll_interval":  {"cli": "-P", "type": int, "help": "Seconds between squeue polls when waiting for job completion (default: 30)."},
         "account":        {"cli": "-a", "type": str, "help": "The account WCID to charge for the SLURM job."},
+        "accounting_timeout": {"cli": "-at", "type": str, "help": "Time until giving up retrieving job's sacct exit code."},
     },
     "output": {
         "debug": {"cli": "-d", "type": bool, "help": "Whether to enable debug logging."},
@@ -128,6 +129,7 @@ class Configuration:
         self.partition = "short"
         self.account = None
         self.poll_interval = 30
+        self.accounting_timeout = 240
 
         # Workflow configuration
         self.remote_root = "hpctools_campaigns"

--- a/romtools/hpc/dispatcher_base.py
+++ b/romtools/hpc/dispatcher_base.py
@@ -41,7 +41,7 @@ class DispatcherBase:
     def create_empty_dir(self, dir_name: str):
         pass
 
-    def dispatch(self, cmd: str, run_directory: str = None) -> int:
+    def dispatch(self, cmd: str, run_directory: str = None) -> str:
         pass
 
     def np_savetxt(self, path: str, arr: np.ndarray, fmt: str) -> None:

--- a/romtools/hpc/dispatcher_base.py
+++ b/romtools/hpc/dispatcher_base.py
@@ -41,7 +41,7 @@ class DispatcherBase:
     def create_empty_dir(self, dir_name: str):
         pass
 
-    def dispatch(self, cmd: str, run_directory: str = None) -> str:
+    def dispatch(self, cmd: str, run_directory: str = None) -> int:
         pass
 
     def np_savetxt(self, path: str, arr: np.ndarray, fmt: str) -> None:

--- a/romtools/hpc/local_dispatcher.py
+++ b/romtools/hpc/local_dispatcher.py
@@ -47,7 +47,12 @@ class LocalDispatcher(DispatcherBase):
     def create_empty_dir(self, dir_name: str):
         os.makedirs(dir_name, exist_ok=True)
 
-    def dispatch(self, cmd: str, run_directory: str = None) -> int:
+    def dispatch(self, cmd: str, run_directory: str = None) -> str:
+        """
+        Returns:
+            sacct format string of job exit code + linux signal number (always 0 in local)
+            example: '0:0'
+        """
         full_cmd = f"cd {shlex.quote(run_directory)} && {cmd}" if run_directory else cmd
         result = subprocess.run(
             full_cmd,
@@ -55,7 +60,7 @@ class LocalDispatcher(DispatcherBase):
             capture_output=True,
             text=True
         )
-        return result.returncode
+        return f"{result.returncode}:0"
 
     def np_savetxt(self, path: str, arr: np.ndarray, fmt: str) -> None:
         np.savetxt(path, arr, fmt=fmt)

--- a/romtools/hpc/local_dispatcher.py
+++ b/romtools/hpc/local_dispatcher.py
@@ -47,7 +47,7 @@ class LocalDispatcher(DispatcherBase):
     def create_empty_dir(self, dir_name: str):
         os.makedirs(dir_name, exist_ok=True)
 
-    def dispatch(self, cmd: str, run_directory: str = None) -> None:
+    def dispatch(self, cmd: str, run_directory: str = None) -> int:
         full_cmd = f"cd {shlex.quote(run_directory)} && {cmd}" if run_directory else cmd
         result = subprocess.run(
             full_cmd,
@@ -55,7 +55,7 @@ class LocalDispatcher(DispatcherBase):
             capture_output=True,
             text=True
         )
-        return Result(result.stdout, result.stderr, result.returncode)
+        return result.returncode
 
     def np_savetxt(self, path: str, arr: np.ndarray, fmt: str) -> None:
         np.savetxt(path, arr, fmt=fmt)

--- a/romtools/hpc/local_dispatcher.py
+++ b/romtools/hpc/local_dispatcher.py
@@ -5,7 +5,6 @@ import shlex
 import subprocess
 import numpy as np
 
-from romtools.hpc.connection import Result
 from romtools.hpc.util.logger import Logger
 from romtools.hpc.dispatcher_base import DispatcherBase
 

--- a/romtools/hpc/remote_dispatcher.py
+++ b/romtools/hpc/remote_dispatcher.py
@@ -10,6 +10,7 @@ import posixpath as ppath
 from typing import Optional
 
 from romtools.hpc.util.logger import Logger
+from romtools.hpc.util.slurm import SLURM_TERMINAL_STATES, get_sacct_status
 from romtools.hpc.collector import Collector
 from romtools.hpc.connection import Connection
 from romtools.hpc.dispatcher_base import DispatcherBase
@@ -17,18 +18,6 @@ from romtools.hpc.dispatcher_base import DispatcherBase
 from romtools.hpc.util.slurm import create_slurm_script
 
 ## ----------------------------------------------------------------------------
-
-SLURM_TERMINAL_STATES = {
-    "BOOT_FAIL",
-    "CANCELLED",
-    "COMPLETED",
-    "DEADLINE",
-    "FAILED",
-    "NODE_FAIL",
-    "OUT_OF_MEMORY",
-    "PREEMPTED",
-    "TIMEOUT",
-}
 
 class RemoteDispatcher(DispatcherBase):
     """
@@ -219,64 +208,57 @@ class RemoteDispatcher(DispatcherBase):
         except Exception as e:
             self.logger.log(f"Failed to cancel job {job_id}: {e}")
 
-    def __get_sacct_status(self, job_id: str, sacct_start_time: str = None):
-        """
-        Return the SLURM accounting state and exit code for a completed/disappeared job.
 
-        Returns:
-            tuple[str, str] | tuple[None, None]:
-                (state, exit_code), or (None, None) if sacct does not have the record yet.
-        """
-        jid = shlex.quote(str(job_id))
+    def __wait_for_status(self, job_id: str):
+        timeout = self.config.get("timeout")
+        start_wait = time.time()
+        poll_interval = 5
 
-        cmd = (
-            f"sacct -j {jid} -X -n -P "
-            "--format=JobIDRaw,State%30,ExitCode"
-        )
+        while True:
+            state, exit_code = get_sacct_status(job_id, self.conn, self.logger)
 
-        if sacct_start_time is not None:
-            cmd += f" --starttime {shlex.quote(sacct_start_time)}"
+            elapsed = time.time() - start_wait
+            if state is None:
+                if elapsed > timeout:
+                    return -1
 
-        result = self.conn.run(cmd)
-
-        if not result.ok:
-            self.logger.debug(f"sacct failed for job {job_id}: {result.stderr}")
-            return None, None
-
-        for line in result.stdout.splitlines():
-            line = line.strip()
-            if not line:
+                self.logger.debug(
+                    f"Job {job_id} is no longer in squeue, but sacct has no "
+                    f"record yet. Waiting..."
+                )
+                time.sleep(poll_interval)
                 continue
 
-            parts = line.split("|")
-            if len(parts) < 3:
+            self.logger.debug(
+                f"sacct reports job {job_id}: state={state}, exit_code={exit_code}"
+            )
+
+            if state not in SLURM_TERMINAL_STATES:
+                if elapsed > timeout:
+                    return -1
+                time.sleep(poll_interval)
                 continue
 
-            sacct_job_id = parts[0].strip()
-            state = parts[1].strip().split()[0].upper()
-            exit_code = parts[2].strip()
+            if not (state == "COMPLETED" and exit_code == "0:0"):
+                self.logger.log(
+                    f"Job {job_id} finished unsuccessfully: state={state}, exit_code={exit_code}"
+                )
+            return exit_code
 
-            if sacct_job_id == str(job_id):
-                return state, exit_code
-
-        return None, None
-
-    def __wait_for_job(self, job_id: str, sacct_start_time=None) -> str:
+    def __wait_for_job(self, job_id: str) -> str:
         """
         Block until the SLURM job is no longer in the queue (RUNNING or PENDING).
 
         Args:
             job_id:        The SLURM job ID to monitor.
-            poll_interval: Seconds between squeue polls (default: 30).
 
         Returns:
-            -1 if unable to retrieve sacct status
-
-            Job exit code + linux signal number otherwise (the result from sacct)
+            Job exit code + linux signal number (the result from sacct)
             Example: '0:0'
+
+            -1 otherwise
         """
         poll_interval = self.config.get("poll_interval")
-        accounting_timeout = self.config.get("accounting_timeout")
         self.logger.log(f"Polling SLURM job {job_id} every {poll_interval}s (Ctrl+C to cancel job)...")
         try:
             while True:
@@ -288,36 +270,7 @@ class RemoteDispatcher(DispatcherBase):
                 time.sleep(poll_interval)
 
             self.logger.log(f"Job {job_id} completed. Retrieving sacct status...")
-            start_wait = time.time()
-            while True:
-                state, exit_code = self.__get_sacct_status(job_id, sacct_start_time)
-                elapsed = time.time() - start_wait
-                if state is None:
-                    if elapsed > accounting_timeout:
-                        return -1
-
-                    self.logger.debug(
-                        f"Job {job_id} is no longer in squeue, but sacct has no "
-                        f"record yet. Waiting..."
-                    )
-                    time.sleep(min(5, poll_interval))
-                    continue
-
-                self.logger.debug(
-                    f"sacct reports job {job_id}: state={state}, exit_code={exit_code}"
-                )
-
-                if state not in SLURM_TERMINAL_STATES:
-                    if elapsed > accounting_timeout:
-                        return -1
-                    time.sleep(min(5, poll_interval))
-                    continue
-
-                if not (state == "COMPLETED" and exit_code == "0:0"):
-                    self.logger.log(
-                        f"Job {job_id} finished unsuccessfully: state={state}, exit_code={exit_code}"
-                    )
-                return exit_code
+            return self.__wait_for_status(job_id)
 
         except KeyboardInterrupt:
             self.__cancel_job(job_id)
@@ -376,23 +329,6 @@ class RemoteDispatcher(DispatcherBase):
             raise RuntimeError(f"Command failed ({cmd}): {res.stderr}")
         self.logger.debug(f"Executed command on remote host: {cmd}")
 
-    def __get_remote_sacct_start_time(self, margin_seconds: int = 60) -> str:
-        """
-        Return a Slurm-compatible timestamp from the remote machine's timezone.
-        """
-        margin_seconds = int(margin_seconds)
-
-        result = self.conn.run(
-            f"date -d '{margin_seconds} seconds ago' '+%Y-%m-%dT%H:%M:%S'"
-        )
-
-        if not result.ok:
-            raise RuntimeError(
-                f"Failed to get remote time for sacct start time: {result.stderr}"
-            )
-
-        return result.stdout.strip()
-
     def dispatch(self, cmd: str = None, run_directory: str = None, with_slurm : bool = True) -> str:
         """
         Main method of the Dispatcher. Dispatches provided work to the
@@ -413,9 +349,8 @@ class RemoteDispatcher(DispatcherBase):
         if not with_slurm:
             self.__run(cmd, run_directory=run_directory)
             return "No SLURM job submitted."
-        sacct_start_time = self.__get_remote_sacct_start_time()
         job_id = self.__submit_slurm_job(cmd, run_directory)
-        status = self.__wait_for_job(job_id, sacct_start_time)
+        status = self.__wait_for_job(job_id)
         self.collector.collect_results()
         return status
 

--- a/romtools/hpc/remote_dispatcher.py
+++ b/romtools/hpc/remote_dispatcher.py
@@ -272,8 +272,8 @@ class RemoteDispatcher(DispatcherBase):
         Returns:
             -1 if unable to retrieve sacct status
 
-            job exit code + linux signal number otherwise (the result from sacct)
-            '0:0', etc
+            Job exit code + linux signal number otherwise (the result from sacct)
+            Example: '0:0'
         """
         poll_interval = self.config.get("poll_interval")
         accounting_timeout = self.config.get("accounting_timeout")

--- a/romtools/hpc/remote_dispatcher.py
+++ b/romtools/hpc/remote_dispatcher.py
@@ -19,6 +19,21 @@ from romtools.hpc.util.slurm import create_slurm_script
 
 ## ----------------------------------------------------------------------------
 
+SLURM_TERMINAL_STATES = {
+    "BOOT_FAIL",
+    "CANCELLED",
+    "COMPLETED",
+    "DEADLINE",
+    "FAILED",
+    "NODE_FAIL",
+    "OUT_OF_MEMORY",
+    "PREEMPTED",
+    "TIMEOUT",
+}
+JOB_SUCCESS = 0
+JOB_FAILED = 1
+JOB_STATUS_UNKNOWN = 2
+
 class RemoteDispatcher(DispatcherBase):
     """
     Main class of ROM's HPC tools. Establishes SSH connection to remote host, dispatches
@@ -208,15 +223,63 @@ class RemoteDispatcher(DispatcherBase):
         except Exception as e:
             self.logger.log(f"Failed to cancel job {job_id}: {e}")
 
-    def __wait_for_job(self, job_id: str) -> None:
+    def __get_sacct_status(self, job_id: str, sacct_start_time: str = None):
+        """
+        Return the SLURM accounting state and exit code for a completed/disappeared job.
+
+        Returns:
+            tuple[str, str] | tuple[None, None]:
+                (state, exit_code), or (None, None) if sacct does not have the record yet.
+        """
+        jid = shlex.quote(str(job_id))
+
+        cmd = (
+            f"sacct -j {jid} -X -n -P "
+            "--format=JobIDRaw,State%30,ExitCode"
+        )
+
+        if sacct_start_time is not None:
+            cmd += f" --starttime {shlex.quote(sacct_start_time)}"
+
+        result = self.conn.run(cmd)
+
+        if not result.ok:
+            self.logger.debug(f"sacct failed for job {job_id}: {result.stderr}")
+            return None, None
+
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            parts = line.split("|")
+            if len(parts) < 3:
+                continue
+
+            sacct_job_id = parts[0].strip()
+            state = parts[1].strip().split()[0].upper()
+            exit_code = parts[2].strip()
+
+            if sacct_job_id == str(job_id):
+                return state, exit_code
+
+        return None, None
+
+    def __wait_for_job(self, job_id: str, sacct_start_time=None) -> int:
         """
         Block until the SLURM job is no longer in the queue (RUNNING or PENDING).
 
         Args:
             job_id:        The SLURM job ID to monitor.
             poll_interval: Seconds between squeue polls (default: 30).
+
+        Returns:
+            0: Success
+            1: Failed
+            2: Unknown
         """
         poll_interval = self.config.get("poll_interval")
+        accounting_timeout = self.config.get("accounting_timeout")
         self.logger.log(f"Polling SLURM job {job_id} every {poll_interval}s (Ctrl+C to cancel job)...")
         try:
             while True:
@@ -226,7 +289,41 @@ class RemoteDispatcher(DispatcherBase):
                     break
                 self.logger.debug(f"Job {job_id} still running...")
                 time.sleep(poll_interval)
-            self.logger.log(f"Job {job_id} completed.")
+
+            self.logger.log(f"Job {job_id} completed. Retrieving sacct status...")
+            start_wait = time.time()
+            while True:
+                state, exit_code = self.__get_sacct_status(job_id, sacct_start_time)
+                elapsed = time.time() - start_wait
+                if state is None:
+                    if elapsed > accounting_timeout:
+                        return JOB_STATUS_UNKNOWN
+
+                    self.logger.debug(
+                        f"Job {job_id} is no longer in squeue, but sacct has no "
+                        f"record yet. Waiting..."
+                    )
+                    time.sleep(min(5, poll_interval))
+                    continue
+
+                self.logger.debug(
+                    f"sacct reports job {job_id}: state={state}, exit_code={exit_code}"
+                )
+
+                if state not in SLURM_TERMINAL_STATES:
+                    if elapsed > accounting_timeout:
+                        return JOB_STATUS_UNKNOWN
+                    time.sleep(min(5, poll_interval))
+                    continue
+
+                if state == "COMPLETED" and exit_code == "0:0":
+                    return JOB_SUCCESS
+
+                self.logger.log(
+                    f"Job {job_id} finished unsuccessfully: state={state}, exit_code={exit_code}"
+                )
+                return JOB_FAILED
+
         except KeyboardInterrupt:
             self.__cancel_job(job_id)
             raise
@@ -284,7 +381,24 @@ class RemoteDispatcher(DispatcherBase):
             raise RuntimeError(f"Command failed ({cmd}): {res.stderr}")
         self.logger.debug(f"Executed command on remote host: {cmd}")
 
-    def dispatch(self, cmd: str = None, run_directory: str = None, with_slurm : bool = True) -> str:
+    def __get_remote_sacct_start_time(self, margin_seconds: int = 60) -> str:
+        """
+        Return a Slurm-compatible timestamp from the remote machine's timezone.
+        """
+        margin_seconds = int(margin_seconds)
+
+        result = self.conn.run(
+            f"date -d '{margin_seconds} seconds ago' '+%Y-%m-%dT%H:%M:%S'"
+        )
+
+        if not result.ok:
+            raise RuntimeError(
+                f"Failed to get remote time for sacct start time: {result.stderr}"
+            )
+
+        return result.stdout.strip()
+
+    def dispatch(self, cmd: str = None, run_directory: str = None, with_slurm : bool = True) -> int:
         """
         Main method of the Dispatcher. Dispatches provided work to the
         remote host, polls the job, and collects results.
@@ -304,10 +418,11 @@ class RemoteDispatcher(DispatcherBase):
         if not with_slurm:
             self.__run(cmd, run_directory=run_directory)
             return "No SLURM job submitted."
+        sacct_start_time = self.__get_remote_sacct_start_time()
         job_id = self.__submit_slurm_job(cmd, run_directory)
-        self.__wait_for_job(job_id)
+        status = self.__wait_for_job(job_id, sacct_start_time)
         self.collector.collect_results()
-        return job_id
+        return status
 
     def np_savetxt(self, path: str, arr: np.ndarray, fmt: str) -> None:
         buffer = io.StringIO()

--- a/romtools/hpc/remote_dispatcher.py
+++ b/romtools/hpc/remote_dispatcher.py
@@ -12,7 +12,6 @@ from typing import Optional
 from romtools.hpc.util.logger import Logger
 from romtools.hpc.collector import Collector
 from romtools.hpc.connection import Connection
-from romtools.hpc.configuration import Configuration
 from romtools.hpc.dispatcher_base import DispatcherBase
 
 from romtools.hpc.util.slurm import create_slurm_script
@@ -30,9 +29,6 @@ SLURM_TERMINAL_STATES = {
     "PREEMPTED",
     "TIMEOUT",
 }
-JOB_SUCCESS = 0
-JOB_FAILED = 1
-JOB_STATUS_UNKNOWN = 2
 
 class RemoteDispatcher(DispatcherBase):
     """
@@ -265,7 +261,7 @@ class RemoteDispatcher(DispatcherBase):
 
         return None, None
 
-    def __wait_for_job(self, job_id: str, sacct_start_time=None) -> int:
+    def __wait_for_job(self, job_id: str, sacct_start_time=None) -> str:
         """
         Block until the SLURM job is no longer in the queue (RUNNING or PENDING).
 
@@ -274,9 +270,10 @@ class RemoteDispatcher(DispatcherBase):
             poll_interval: Seconds between squeue polls (default: 30).
 
         Returns:
-            0: Success
-            1: Failed
-            2: Unknown
+            -1 if unable to retrieve sacct status
+
+            job exit code + linux signal number otherwise (the result from sacct)
+            '0:0', etc
         """
         poll_interval = self.config.get("poll_interval")
         accounting_timeout = self.config.get("accounting_timeout")
@@ -297,7 +294,7 @@ class RemoteDispatcher(DispatcherBase):
                 elapsed = time.time() - start_wait
                 if state is None:
                     if elapsed > accounting_timeout:
-                        return JOB_STATUS_UNKNOWN
+                        return -1
 
                     self.logger.debug(
                         f"Job {job_id} is no longer in squeue, but sacct has no "
@@ -312,17 +309,15 @@ class RemoteDispatcher(DispatcherBase):
 
                 if state not in SLURM_TERMINAL_STATES:
                     if elapsed > accounting_timeout:
-                        return JOB_STATUS_UNKNOWN
+                        return -1
                     time.sleep(min(5, poll_interval))
                     continue
 
-                if state == "COMPLETED" and exit_code == "0:0":
-                    return JOB_SUCCESS
-
-                self.logger.log(
-                    f"Job {job_id} finished unsuccessfully: state={state}, exit_code={exit_code}"
-                )
-                return JOB_FAILED
+                if not (state == "COMPLETED" and exit_code == "0:0"):
+                    self.logger.log(
+                        f"Job {job_id} finished unsuccessfully: state={state}, exit_code={exit_code}"
+                    )
+                return exit_code
 
         except KeyboardInterrupt:
             self.__cancel_job(job_id)
@@ -398,7 +393,7 @@ class RemoteDispatcher(DispatcherBase):
 
         return result.stdout.strip()
 
-    def dispatch(self, cmd: str = None, run_directory: str = None, with_slurm : bool = True) -> int:
+    def dispatch(self, cmd: str = None, run_directory: str = None, with_slurm : bool = True) -> str:
         """
         Main method of the Dispatcher. Dispatches provided work to the
         remote host, polls the job, and collects results.
@@ -413,7 +408,7 @@ class RemoteDispatcher(DispatcherBase):
             with_slurm: If True, the command will be run as a SLURM job.
                  If False, the command will be executed directly without SLURM.
 
-        Returns the SLURM job ID if applicable.
+        Returns the SLURM job exit code in sacct format of 0:0, or "No SLURM JOB submitted.".
         """
         if not with_slurm:
             self.__run(cmd, run_directory=run_directory)

--- a/romtools/hpc/util/slurm.py
+++ b/romtools/hpc/util/slurm.py
@@ -1,4 +1,19 @@
 import textwrap
+import shlex
+
+from romtools.hpc.connection import Connection
+
+SLURM_TERMINAL_STATES = {
+    "BOOT_FAIL",
+    "CANCELLED",
+    "COMPLETED",
+    "DEADLINE",
+    "FAILED",
+    "NODE_FAIL",
+    "OUT_OF_MEMORY",
+    "PREEMPTED",
+    "TIMEOUT",
+}
 
 def create_slurm_script(job_name: str, num_nodes: int, tasks_per_node: int, wall_time: str, wcid: str, partition: str, command: str) -> str:
     """
@@ -26,3 +41,42 @@ def create_slurm_script(job_name: str, num_nodes: int, tasks_per_node: int, wall
 {command}
 """)
     return slurm_script
+
+def get_sacct_status(job_id: str, conn: Connection, logger):
+    """
+    Return the SLURM accounting state and exit code for a completed/disappeared job.
+
+    Returns:
+        tuple[str, str] | tuple[None, None]:
+            (state, exit_code), or (None, None) if sacct does not have the record yet.
+    """
+    jid = shlex.quote(str(job_id))
+
+    cmd = (
+        f"sacct -j {jid} -X -n -P "
+        "--format=JobIDRaw,State%30,ExitCode"
+    )
+
+    result = conn.run(cmd)
+
+    if not result.ok:
+        logger.log(f"sacct failed for job {job_id}: {result.stderr}")
+        return None, None
+
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split("|")
+        if len(parts) < 3:
+            continue
+
+        sacct_job_id = parts[0].strip()
+        state = parts[1].strip().split()[0].upper()
+        exit_code = parts[2].strip()
+
+        if sacct_job_id == str(job_id):
+            return state, exit_code
+
+    return None, None

--- a/tests/romtools/hpc/conftest.py
+++ b/tests/romtools/hpc/conftest.py
@@ -1,10 +1,12 @@
 import io
 import sys
 import tarfile
+import time
 
 import pytest
 
 from romtools.hpc.connection import Result
+from romtools.hpc.configuration import Configuration
 
 
 class FakeConnection:
@@ -29,6 +31,11 @@ class FakeConnection:
         for matcher, result in self._responses:
             if matcher in command:
                 return result() if callable(result) else result
+
+        # fallbacks
+        if "date -d" in command:
+            Result(stdout=str(time.time()), stderr="", exited=0)
+
         return Result(stdout="", stderr="", exited=0)
 
     def put(self, local, remote):
@@ -65,23 +72,10 @@ def fake_connection():
 @pytest.fixture
 def make_config():
     def _make(**overrides):
-        config = {
-            "remote": "test-host",
-            "user": "test-user",
-            "port": 22,
-            "script": None,
-            "job_name": "test_job",
-            "num_nodes": 1,
-            "tasks_per_node": 1,
-            "wall_time": "00:01:00",
-            "partition": "short",
-            "account": "test-account",
-            "poll_interval": 0,
-            "remote_root": "hpctools_campaigns",
-            "debug": False,
-            "collect": None,
-            "user_defined": {},
-        }
+        config = Configuration().to_dict()
+        config['remote'] = "test-host"
+        config['user'] = 'test-user'
+        config['accounting_timeout'] = 0
         config.update(overrides)
         return config
 

--- a/tests/romtools/hpc/conftest.py
+++ b/tests/romtools/hpc/conftest.py
@@ -75,7 +75,7 @@ def make_config():
         config = Configuration().to_dict()
         config['remote'] = "test-host"
         config['user'] = 'test-user'
-        config['accounting_timeout'] = 0
+        config['timeout'] = 0
         config.update(overrides)
         return config
 

--- a/tests/romtools/hpc/test_local_dispatcher.py
+++ b/tests/romtools/hpc/test_local_dispatcher.py
@@ -98,29 +98,25 @@ def test_np_savez_round_trip(tmp_path, dispatcher):
 def test_dispatch_runs_command_and_captures_output(tmp_path, dispatcher):
     result = dispatcher.dispatch("echo hello", run_directory=str(tmp_path))
 
-    assert result.ok
-    assert result.stdout.strip() == "hello"
+    assert result == "0:0"
 
 
 def test_dispatch_without_run_directory_runs_in_cwd(dispatcher):
     result = dispatcher.dispatch("echo hello")
 
-    assert result.ok
-    assert result.stdout.strip() == "hello"
+    assert result == "0:0"
 
 
 def test_dispatch_reports_failure_without_raising(dispatcher):
     result = dispatcher.dispatch("exit 1")
 
-    assert not result.ok
-    assert result.exited == 1
+    assert result == "1:0"
 
 
 def test_dispatch_runs_relative_to_run_directory(tmp_path, dispatcher):
     marker = tmp_path / "marker.txt"
     marker.write_text("present")
 
-    result = dispatcher.dispatch("cat marker.txt", run_directory=str(tmp_path))
+    result = dispatcher.dispatch("grep -qF 'present' marker.txt", run_directory=str(tmp_path))
 
-    assert result.ok
-    assert result.stdout.strip() == "present"
+    assert result == "0:0"

--- a/tests/romtools/hpc/test_remote_dispatcher.py
+++ b/tests/romtools/hpc/test_remote_dispatcher.py
@@ -60,14 +60,15 @@ def test_dispatch_with_slurm_submits_polls_and_collects(monkeypatch, make_config
         ("squeue -j 123 -h", Result("", "", 0)),
         ("tar -czf", Result("", "", 0)),
         ("rm -f", Result("", "", 0)),
+        ("sacct -j", Result("123 | COMPLETED | 0:0", "", 0)),
     ]
     conn = ArchiveFakeConnection(responses=responses)
     config = make_config(remote_root="campaigns", job_name="myjob", poll_interval=0, collect=["all"])
     dispatcher = _make_dispatcher(monkeypatch, config, conn)
 
-    job_id = dispatcher.dispatch("./my_app")
+    result = dispatcher.dispatch("./my_app")
 
-    assert job_id == "123"
+    assert result == "0:0"
     assert any(c.startswith("cd campaigns/hpctools && sbatch") for c in conn.calls)
     assert any(c == "squeue -j 123 -h" for c in conn.calls)
     assert any(c.startswith("rm -f") for c in conn.calls)


### PR DESCRIPTION
Currently, the remote dispatcher does not return the job status. This change returns the job status from `dispatch()` based on status info acquired from `sacct`, and unified the `dispatch()` function signature between the `remote` and `local` dispatcher. 